### PR TITLE
feat(sensor): add `state_class=measurement` to temp./humid.

### DIFF
--- a/src/hass_mqtt/sensor.rs
+++ b/src/hass_mqtt/sensor.rs
@@ -20,9 +20,22 @@ pub struct SensorConfig {
 
     pub state_topic: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_class: Option<StateClass>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub unit_of_measurement: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub json_attributes_topic: Option<String>,
+}
+
+#[allow(unused)]
+#[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StateClass {
+    #[serde(rename="measurement")]
+    Measurement,
+    #[serde(rename="total")]
+    Total,
+    #[serde(rename="total_increasing")]
+    TotalIncreasing
 }
 
 impl SensorConfig {
@@ -70,6 +83,7 @@ impl GlobalFixedDiagnostic {
                     icon: None,
                 },
                 state_topic: format!("gv2mqtt/sensor/{unique_id}/state"),
+                state_class: None,
                 unit_of_measurement: None,
                 json_attributes_topic: None,
             },
@@ -110,6 +124,12 @@ impl CapabilitySensor {
             _ => None,
         };
 
+        let state_class = match instance.instance.as_str() {
+            "sensorTemperature" => Some(StateClass::Measurement),
+            "sensorHumidity" => Some(StateClass::Measurement),
+            _ => None,
+        };
+
         let name = match instance.instance.as_str() {
             "sensorTemperature" => "Temperature".to_string(),
             "sensorHumidity" => "Humidity".to_string(),
@@ -130,6 +150,7 @@ impl CapabilitySensor {
                     icon: None,
                 },
                 state_topic: format!("gv2mqtt/sensor/{unique_id}/state"),
+                state_class: state_class,
                 unit_of_measurement,
                 json_attributes_topic: None,
             },
@@ -227,6 +248,7 @@ impl DeviceStatusDiagnostic {
                     icon: None,
                 },
                 state_topic: format!("gv2mqtt/sensor/{unique_id}/state"),
+                state_class: None,
                 json_attributes_topic: Some(format!("gv2mqtt/sensor/{unique_id}/attributes")),
                 unit_of_measurement: None,
             },


### PR DESCRIPTION
### Goal

Enable [long-term statistics](https://data.home-assistant.io/docs/statistics/) recording of temperature & humidity sensor readings for [H5179](https://eu.govee.com/products/wi-fi-thermo-hygrometer) (Wi-Fi Thermo-Hygrometer).

### Context

By default the [`recorder`](https://www.home-assistant.io/integrations/recorder) integration only retains 10 days of sensor data ([`purge_keep_days`](https://www.home-assistant.io/integrations/recorder/#purge_keep_days)).

Below you can see, how the blue Govee line only dates back 10 days. At the same date the violet Hue line transitions from solid to translucent to indicate falling back to the long-term statistics data source.

![image](https://github.com/wez/govee2mqtt/assets/834636/233baa52-638d-436c-8440-00ffa41caa55)

> Home Assistant has support for storing sensors as long-term statistics, if the entity has the right properties. To opt-in for statistics, the sensor must have `state_class` set to one of the valid state classes: `measurement`, `total` or `total_increasing`. [...]

— https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics

### Changes

 - add the optional `state_class` string enum field to the `SensorConfig` struct
 - configure `sensorTemperature` & `sensoreHumidity` to use the `measurement` `state_class`

### Remarks

This PR is currently untested (but it compiles), as I'm a Rust and Home Assistant Addon development novice. I'll report back, when I was able to successfully install & test my changes in my personal Home Assistant installation, unless you think that's not necessary.

I'm not entirely sure that my changes are correct and idiomatic, so any and all criticism is appreciated.

P.S.: _Thank you_ for this amazing addon. 💖 