### PR TITLE
Add quirk for H7170 kettle to report proper temperature

### DIFF
--- a/src/service/quirks.rs
+++ b/src/service/quirks.rs
@@ -233,6 +233,8 @@ fn load_quirks() -> HashMap<String, Quirk> {
         Quirk::thermometer("H5179")
             .with_platform_temperature_sensor_units(TemperatureUnits::CelsiusTimes100)
             .with_platform_humidity_sensor_units(HumidityUnits::RelativePercentTimes100),
+        Quirk::device("H7170", DeviceType::Kettle, "mdi:kettle")
+            .with_platform_temperature_sensor_units(TemperatureUnits::Farenheit),
         Quirk::device("H7171", DeviceType::Kettle, "mdi:kettle")
             .with_platform_temperature_sensor_units(TemperatureUnits::Farenheit)
             .with_show_as_preset_modes(&["M1", "M2", "M3", "M4"]),


### PR DESCRIPTION
The Govee API reports temperature in Fahrenheit for the H7170 Kettle:

![image](https://github.com/wez/govee2mqtt/assets/4690239/9fec6ce5-09d5-42f7-8a53-1391cabbd46b)

This correct this and allows the kettle to report the proper temperature. 