### PR TITLE
fix: include H5086 in alternate power state configuration

### DIFF
--- a/src/service/iot.rs
+++ b/src/service/iot.rs
@@ -56,7 +56,7 @@ impl IotClient {
         }
 
         let power_state = match device.sku.as_str() {
-            "H5080" | "H5083" => pwr(on, 17, 16),
+            "H5080" | "H5083" | "H5086" => pwr(on, 17, 16),
             _ => pwr(on, 1, 0),
         };
 


### PR DESCRIPTION
Hoping this will correct the on/off actions on H5086 switches.

closes #186 