### PR TITLE
Invert sense of GOVEE_LAN_NO_MULTICAST environment variable

### DIFF
--- a/src/lan_api.rs
+++ b/src/lan_api.rs
@@ -84,7 +84,7 @@ impl LanDiscoArguments {
         };
 
         if let Some(v) = opt_env_var::<String>("GOVEE_LAN_NO_MULTICAST")? {
-            options.enable_multicast = truthy(&v)?;
+            options.enable_multicast = !truthy(&v)?;
         }
 
         if let Some(v) = opt_env_var::<String>("GOVEE_LAN_BROADCAST_ALL")? {


### PR DESCRIPTION
The docs say that `GOVEE_LAN_NO_MULTICAST=true` should *disable* multicast discovery:
https://github.com/wez/govee2mqtt/blob/main/docs/CONFIG.md#lan-api-control

However, because the sense of the environment variable was not inverted, you actually had to do `GOVEE_LAN_NO_MULTICAST=false` to get this effect.

(If you're curious, the reason I wanted this was because I have no LAN-capable devices anyway, and this is one way to bypass the time spent on scanning for LAN devices.)