### PR TITLE
Add unit-related quirks to H5100 sensor

### DIFF
--- a/src/service/quirks.rs
+++ b/src/service/quirks.rs
@@ -230,6 +230,9 @@ fn load_quirks() -> HashMap<String, Quirk> {
         Quirk::thermometer("H5051")
             .with_platform_temperature_sensor_units(TemperatureUnits::Farenheit)
             .with_platform_humidity_sensor_units(HumidityUnits::RelativePercent),
+        Quirk::thermometer("H5100")
+            .with_platform_temperature_sensor_units(TemperatureUnits::Farenheit)
+            .with_platform_humidity_sensor_units(HumidityUnits::RelativePercent),
         Quirk::thermometer("H5103")
             .with_platform_temperature_sensor_units(TemperatureUnits::Farenheit)
             .with_platform_humidity_sensor_units(HumidityUnits::RelativePercent),


### PR DESCRIPTION
Fixes #240. It appears that this sensor uses the same reporting style as H5103, which were addressed in #232. I tested this with a few H5100s I have and the readings now appear accurate.