### PR TITLE
Correct spelling of Fahrenheit. 

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -568,7 +568,7 @@ refs: https://github.com/wez/govee2mqtt/issues/75
 
 This commit introduces a configuration option to specify your
 preferred temperature scale as either "C" or "F" for Celsius
-or Farenheit, respectively.
+or Fahrenheit, respectively.
 
 Entities created in home assistant will be set to use those units,
 and convert to the underlying device units.

--- a/addon/translations/en.yaml
+++ b/addon/translations/en.yaml
@@ -4,7 +4,7 @@ configuration:
     name: Temperature Scale
     description: >-
       Specify which temperature scale to use when mapping entities
-      into Home Assistant. Can be either "C" for Celsius or "F" for Farenheit.
+      into Home Assistant. Can be either "C" for Celsius or "F" for Fahrenheit.
   govee_email:
     name: Govee Account Email
     description: >-

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -24,7 +24,7 @@ GOVEE_MQTT_PORT=1883
 #GOVEE_MQTT_PASSWORD=password
 
 # Specify the temperature scale to use, either C for Celsius
-# or F for Farenheit
+# or F for Fahrenheit
 GOVEE_TEMPERATURE_SCALE=C
 
 # Always use colorized output

--- a/src/hass_mqtt/climate.rs
+++ b/src/hass_mqtt/climate.rs
@@ -49,7 +49,7 @@ pub fn parse_temperature_constraints(
                     .and_then(|s| TemperatureScale::from_str(s).map(Into::into).ok())
             })
         })
-        .unwrap_or(TemperatureUnits::Farenheit);
+        .unwrap_or(TemperatureUnits::Fahrenheit);
 
     let temperature = instance
         .struct_field_by_name("temperature")

--- a/src/service/hass.rs
+++ b/src/service/hass.rs
@@ -51,7 +51,7 @@ pub struct HassArguments {
 
     /// The temperature scale to use when showing temperature values as
     /// entities in home assistant. Can be either "C" or "F" for Celsius
-    /// or Farenheit respectively.
+    /// or Fahrenheit respectively.
     /// You may also set this vai the GOVEE_TEMPERATURE_SCALE environment
     /// variable.
     #[arg(long, global = true)]

--- a/src/service/quirks.rs
+++ b/src/service/quirks.rs
@@ -213,39 +213,39 @@ fn load_quirks() -> HashMap<String, Quirk> {
             .with_rgb()
             .with_brightness(),
         Quirk::space_heater("H7130")
-            .with_platform_temperature_sensor_units(TemperatureUnits::Farenheit),
+            .with_platform_temperature_sensor_units(TemperatureUnits::Fahrenheit),
         Quirk::space_heater("H7131")
-            .with_platform_temperature_sensor_units(TemperatureUnits::Farenheit)
+            .with_platform_temperature_sensor_units(TemperatureUnits::Fahrenheit)
             .with_show_as_preset_modes(&["gearMode"])
             .with_rgb()
             .with_brightness(),
         Quirk::space_heater("H713A")
-            .with_platform_temperature_sensor_units(TemperatureUnits::Farenheit),
+            .with_platform_temperature_sensor_units(TemperatureUnits::Fahrenheit),
         Quirk::space_heater("H713B")
-            .with_platform_temperature_sensor_units(TemperatureUnits::Farenheit),
+            .with_platform_temperature_sensor_units(TemperatureUnits::Fahrenheit),
         Quirk::space_heater("H7132")
-            .with_platform_temperature_sensor_units(TemperatureUnits::Farenheit),
+            .with_platform_temperature_sensor_units(TemperatureUnits::Fahrenheit),
         Quirk::space_heater("H7135")
-            .with_platform_temperature_sensor_units(TemperatureUnits::Farenheit),
+            .with_platform_temperature_sensor_units(TemperatureUnits::Fahrenheit),
         Quirk::thermometer("H5051")
-            .with_platform_temperature_sensor_units(TemperatureUnits::Farenheit)
+            .with_platform_temperature_sensor_units(TemperatureUnits::Fahrenheit)
             .with_platform_humidity_sensor_units(HumidityUnits::RelativePercent),
         Quirk::thermometer("H5100")
-            .with_platform_temperature_sensor_units(TemperatureUnits::Farenheit)
+            .with_platform_temperature_sensor_units(TemperatureUnits::Fahrenheit)
             .with_platform_humidity_sensor_units(HumidityUnits::RelativePercent),
         Quirk::thermometer("H5103")
-            .with_platform_temperature_sensor_units(TemperatureUnits::Farenheit)
+            .with_platform_temperature_sensor_units(TemperatureUnits::Fahrenheit)
             .with_platform_humidity_sensor_units(HumidityUnits::RelativePercent),
         Quirk::thermometer("H5179")
-            .with_platform_temperature_sensor_units(TemperatureUnits::Farenheit)
+            .with_platform_temperature_sensor_units(TemperatureUnits::Fahrenheit)
             .with_platform_humidity_sensor_units(HumidityUnits::RelativePercent),
         Quirk::device("H7170", DeviceType::Kettle, "mdi:kettle")
-            .with_platform_temperature_sensor_units(TemperatureUnits::Farenheit),
+            .with_platform_temperature_sensor_units(TemperatureUnits::Fahrenheit),
         Quirk::device("H7171", DeviceType::Kettle, "mdi:kettle")
-            .with_platform_temperature_sensor_units(TemperatureUnits::Farenheit)
+            .with_platform_temperature_sensor_units(TemperatureUnits::Fahrenheit)
             .with_show_as_preset_modes(&["M1", "M2", "M3", "M4"]),
         Quirk::device("H7173", DeviceType::Kettle, "mdi:kettle")
-            .with_platform_temperature_sensor_units(TemperatureUnits::Farenheit)
+            .with_platform_temperature_sensor_units(TemperatureUnits::Fahrenheit)
             .with_show_as_preset_modes(&["Tea", "Coffee", "DIY"]),
         // Lights from the list of LAN API enabled devices
         // at <https://app-h5.govee.com/user-manual/wlan-guide>

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 pub const UNIT_CELSIUS: &str = "°C";
-pub const UNIT_FARENHEIT: &str = "°F";
+pub const UNIT_FAHRENHEIT: &str = "°F";
 pub const DEVICE_CLASS_TEMPERATURE: &str = "temperature";
 
 #[allow(unused)]
@@ -9,22 +9,22 @@ pub const DEVICE_CLASS_TEMPERATURE: &str = "temperature";
 pub enum TemperatureUnits {
     Celsius,
     CelsiusTimes100,
-    Farenheit,
-    FarenheitTimes100,
+    Fahrenheit,
+    FahrenheitTimes100,
 }
 
 impl TemperatureUnits {
     fn factor(&self) -> f64 {
         match self {
-            Self::CelsiusTimes100 | Self::FarenheitTimes100 => 100.,
-            Self::Celsius | Self::Farenheit => 1.,
+            Self::CelsiusTimes100 | Self::FahrenheitTimes100 => 100.,
+            Self::Celsius | Self::Fahrenheit => 1.,
         }
     }
 
     fn scale(&self) -> TemperatureScale {
         match self {
             Self::Celsius | Self::CelsiusTimes100 => TemperatureScale::Celsius,
-            Self::Farenheit | Self::FarenheitTimes100 => TemperatureScale::Farenheit,
+            Self::Fahrenheit | Self::FahrenheitTimes100 => TemperatureScale::Fahrenheit,
         }
     }
 
@@ -44,7 +44,7 @@ impl From<TemperatureScale> for TemperatureUnits {
     fn from(scale: TemperatureScale) -> TemperatureUnits {
         match scale {
             TemperatureScale::Celsius => Self::Celsius,
-            TemperatureScale::Farenheit => Self::Farenheit,
+            TemperatureScale::Fahrenheit => Self::Fahrenheit,
         }
     }
 }
@@ -65,7 +65,7 @@ impl std::fmt::Display for TemperatureUnits {
 pub enum TemperatureScale {
     #[default]
     Celsius,
-    Farenheit,
+    Fahrenheit,
 }
 
 impl std::fmt::Display for TemperatureScale {
@@ -78,7 +78,7 @@ impl TemperatureScale {
     pub fn unit_of_measurement(&self) -> &'static str {
         match self {
             Self::Celsius => UNIT_CELSIUS,
-            Self::Farenheit => UNIT_FARENHEIT,
+            Self::Fahrenheit => UNIT_FAHRENHEIT,
         }
     }
 }
@@ -88,18 +88,18 @@ impl FromStr for TemperatureScale {
     fn from_str(s: &str) -> anyhow::Result<TemperatureScale> {
         match s {
             "c" | "C" | "°c" | "°C" | "Celsius" | "celsius" => Ok(Self::Celsius),
-            "f" | "F" | "°f" | "°F" | "Farenheit" | "farenheit" => Ok(Self::Farenheit),
+            "f" | "F" | "°f" | "°F" | "Fahrenheit" | "fahrenheit" => Ok(Self::Fahrenheit),
             _ => anyhow::bail!("Unknown temperature scale {s}"),
         }
     }
 }
 
-/// Convert farenheit to celsius
+/// Convert fahrenheit to celsius
 pub fn ftoc(f: f64) -> f64 {
     (f - 32.) * (5. / 9.)
 }
 
-/// Convert farenheit to celsius
+/// Convert fahrenheit to celsius
 pub fn ctof(f: f64) -> f64 {
     (f * 9. / 5.) + 32.
 }
@@ -130,9 +130,9 @@ impl TemperatureValue {
         }
     }
 
-    pub fn with_farenheit(value: f64) -> Self {
+    pub fn with_fahrenheit(value: f64) -> Self {
         Self {
-            unit: TemperatureUnits::Farenheit,
+            unit: TemperatureUnits::Fahrenheit,
             value,
         }
     }
@@ -155,10 +155,10 @@ impl TemperatureValue {
         let normalized = self.value / self.unit.factor();
 
         let converted = match (self.unit.scale(), unit.scale()) {
-            (TemperatureScale::Celsius, TemperatureScale::Farenheit) => ctof(normalized),
-            (TemperatureScale::Farenheit, TemperatureScale::Celsius) => ftoc(normalized),
+            (TemperatureScale::Celsius, TemperatureScale::Fahrenheit) => ctof(normalized),
+            (TemperatureScale::Fahrenheit, TemperatureScale::Celsius) => ftoc(normalized),
             (TemperatureScale::Celsius, TemperatureScale::Celsius) => normalized,
-            (TemperatureScale::Farenheit, TemperatureScale::Farenheit) => normalized,
+            (TemperatureScale::Fahrenheit, TemperatureScale::Fahrenheit) => normalized,
         };
 
         Self {
@@ -171,8 +171,8 @@ impl TemperatureValue {
         self.as_unit(TemperatureUnits::Celsius).value
     }
 
-    pub fn as_farenheit(&self) -> f64 {
-        self.as_unit(TemperatureUnits::Farenheit).value
+    pub fn as_fahrenheit(&self) -> f64 {
+        self.as_unit(TemperatureUnits::Fahrenheit).value
     }
 
     pub fn parse_with_optional_scale(
@@ -224,14 +224,14 @@ mod test {
             TemperatureValue::new(23.0, TemperatureUnits::Celsius)
         );
         assert_eq!(
-            TemperatureValue::parse_with_optional_scale("23C", Some(TemperatureScale::Farenheit))
+            TemperatureValue::parse_with_optional_scale("23C", Some(TemperatureScale::Fahrenheit))
                 .unwrap(),
             TemperatureValue::new(23.0, TemperatureUnits::Celsius)
         );
         assert_eq!(
-            TemperatureValue::parse_with_optional_scale("23", Some(TemperatureScale::Farenheit))
+            TemperatureValue::parse_with_optional_scale("23", Some(TemperatureScale::Fahrenheit))
                 .unwrap(),
-            TemperatureValue::new(23.0, TemperatureUnits::Farenheit)
+            TemperatureValue::new(23.0, TemperatureUnits::Fahrenheit)
         );
         assert_eq!(
             TemperatureValue::parse_with_optional_scale("23frogs", None)
@@ -256,20 +256,20 @@ mod test {
     #[test]
     fn value_conversion() {
         assert_eq!(
-            TemperatureValue::new(76., TemperatureUnits::Farenheit)
+            TemperatureValue::new(76., TemperatureUnits::Fahrenheit)
                 .as_celsius()
                 .floor(),
             24.
         );
         assert_eq!(
             TemperatureValue::new(24.444, TemperatureUnits::Celsius)
-                .as_farenheit()
+                .as_fahrenheit()
                 .ceil(),
             76.
         );
         assert_eq!(
-            TemperatureValue::new(76., TemperatureUnits::Farenheit)
-                .as_unit(TemperatureUnits::FarenheitTimes100)
+            TemperatureValue::new(76., TemperatureUnits::Fahrenheit)
+                .as_unit(TemperatureUnits::FahrenheitTimes100)
                 .value,
             7600.
         );


### PR DESCRIPTION
Fixes #247 and #160. 

Noticed the discrepancy in the original trace log:
```
2024-08-01T20:04:43.432208958Z [2024-08-01T13:04:43 DEBUG govee::hass_mqtt::climate] notify_state for Space Heater Pro (XXXXXXXXX H7133) targetTemperature
642
2024-08-01T20:04:43.432214580Z [2024-08-01T13:04:43 DEBUG govee::hass_mqtt::climate] have: DeviceCapabilityState { kind: TemperatureSetting, instance: "targetTemperature", state: Object {"value": Object {"targetTemperature": Number(75), "unit": String("Fahrenheit")}} }
643
2024-08-01T20:04:43.432796255Z [2024-08-01T13:04:43 DEBUG govee::hass_mqtt::climate] units are reported as Celsius
644
2024-08-01T20:04:43.432804395Z [2024-08-01T13:04:43 DEBUG govee::hass_mqtt::climate] reported temp is 75°C, pref_units: °C
645
2024-08-01T20:04:43.432806817Z [2024-08-01T13:04:43 DEBUG govee::hass_mqtt::climate] setting value to 75.00
```