### PR TITLE
Update Docker instructions

### DIFF
--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -40,7 +40,7 @@ TZ=America/Phoenix
 3. Set up your `docker-compose.yml`:
 
 ```yaml
-version: '3.8'
+name: govee2mqtt
 services:
   pv2mqtt:
     image: ghcr.io/wez/govee2mqtt:latest
@@ -50,6 +50,9 @@ services:
       - .env
     # Host networking is required
     network_mode: host
+# By default, a Docker volume will be used to persist data. If you prefer to mount this on your host, you can do so as follows:
+#    volumes:
+#      - '/path/to/data:/data'
 ```
 
 4. Launch it:


### PR DESCRIPTION
The version: directive has been deprecated for quite some time, and has been replaced with the name: invocation.

https://forums.docker.com/t/docker-compose-yml-version-is-obsolete/141313

https://docs.docker.com/reference/compose-file/version-and-name/

Also adding optional bind mount for those who prefer to persist their data. Thanks!