### PR TITLE
fix humidity sensor json mapping

### DIFF
--- a/src/hass_mqtt/sensor.rs
+++ b/src/hass_mqtt/sensor.rs
@@ -204,7 +204,7 @@ impl EntityInstance for CapabilitySensor {
                         .unwrap_or(HumidityUnits::RelativePercent);
                     match cap
                         .state
-                        .pointer("/value/currentHumidity")
+                        .pointer("/value")
                         .and_then(|v| v.as_f64())
                         .map(|v| units.from_reading_to_relative_percent(v))
                     {


### PR DESCRIPTION
Looking into #392 and #379. I added a debug line to sensors.rs to see what json data we were getting back for the humidity sensor.

```
[2025-04-07T09:34:43 DEBUG govee::hass_mqtt::sensor] Humidity sensor state: {"value":63.0}
```

Indeed, it just shows `value` and not `value/currentHumidity`. So change this to just be `value` like temperature fixes the attribute in HA.

```
[2025-04-07T09:34:43 TRACE govee::service::hass] gv2mqtt/sensor/sensor-8AE8E013D57200AA-sensortemperature/state -> 73.22
[2025-04-07T09:34:43 TRACE govee::service::hass] gv2mqtt/sensor/sensor-8AE8E013D57200AA-sensorhumidity/state -> 63.00
```
