### PR TITLE
feat: Retain Home Assistant discovery messages and GC stale devices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,6 @@ on:
       - "Dockerfile"
       - ".dockerignore"
 
-env:
-  IMAGE: ghcr.io/${{ toLower(github.repository) }}
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -38,16 +35,22 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+      - name: Prepare image name
+        id: prep
+        run: |
+          IMAGE_NAME="ghcr.io/${{ github.repository }}"
+          echo "IMAGE_LOWER=${IMAGE_NAME,,}" >> $GITHUB_ENV
       - name: Docker meta
         if: ${{ github.event_name != 'pull_request' }}
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE }}
+          images: ${{ env.IMAGE_LOWER }} 
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=branch,enable=${{ github.ref != 'refs/heads/main' }}
             type=ref,event=pr
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ on:
       - ".dockerignore"
 
 env:
-  IMAGE: ghcr.io/wez/govee2mqtt
+  IMAGE: ghcr.io/${{ github.repository }}
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,10 @@ jobs:
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
+          if [ -z "$digest" ]; then
+            echo "Digest is empty! Build step might have failed."
+            exit 1
+          fi
           touch "/tmp/digests/${digest#sha256:}"
           echo "DIGEST_NAME=$(echo ${{ matrix.platform }} | sed 's,/,-,g')" >> $GITHUB_OUTPUT
       - name: Upload digest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,29 +147,29 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
-  addon:
-    if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
-    runs-on: ubuntu-latest
-    needs:
-      - merge
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: https://ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Apply tag to version
-        run: ./scripts/apply-tag.sh
-      - name: Build and Publish Home Assistant Add On
-        uses: home-assistant/builder@master
-        with:
-          args: |
-            --all \
-            --cosign \
-            --target /data/addon
+#  addon:
+#    if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+#    runs-on: ubuntu-latest
+#    needs:
+#      - merge
+#    permissions:
+#      contents: read
+#      id-token: write
+#      packages: write
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Login to GHCR
+#        uses: docker/login-action@v3
+#        with:
+#          registry: https://ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Apply tag to version
+#        run: ./scripts/apply-tag.sh
+#      - name: Build and Publish Home Assistant Add On
+#        uses: home-assistant/builder@master
+#        with:
+#          args: |
+#            --all \
+#            --cosign \
+#            --target /data/addon

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,6 +128,12 @@ jobs:
           path: /tmp/digests
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Prepare image name
+        id: prep
+        run: |
+          IMAGE_NAME="ghcr.io/${{ github.repository }}"
+          echo "IMAGE_LOWER=${IMAGE_NAME,,}" >> $GITHUB_ENV
+          echo "IMAGE=${IMAGE_NAME,,}" >> $GITHUB_ENV 
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           IMAGE_NAME="ghcr.io/${{ github.repository }}"
           echo "IMAGE_LOWER=${IMAGE_NAME,,}" >> $GITHUB_ENV
+          echo "IMAGE=${IMAGE_NAME,,}" >> $GITHUB_ENV 
       - name: Docker meta
         if: ${{ github.event_name != 'pull_request' }}
         id: meta

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ on:
       - ".dockerignore"
 
 env:
-  IMAGE: ghcr.io/${{ github.repository }}
+  IMAGE: ghcr.io/${{ toLower(github.repository) }}
 
 jobs:
   build:

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,0 +1,51 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      IMAGE_NAME: govee2mqtt
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install cross
+        run: cargo install cross
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build cross-platform binaries
+        run: |
+          ./scripts/build-cross.sh linux/amd64
+          ./scripts/build-cross.sh linux/arm64
+
+      - name: Build and push multi-arch Docker image
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --push \
+            -t ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:latest \
+            -t ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:${{ github.sha }} .

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=$BUILDPLATFORM alpine:latest AS builder
 ARG TARGETPLATFORM
 
 # Rust und benötigte Tools installieren
-RUN apk add --no-cache build-base openssl-dev curl
+RUN apk add --no-cache build-base openssl-dev curl perl
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ COPY --from=builder --chown=govee:govee /data /data
 COPY assets /app/assets
 
 USER govee:govee
-LABEL org.opencontainers.image.source="https://github.com/jmerifjKriwe/govee2mqtt"
+LABEL org.opencontainers.image.source="https://github.com/wez/govee2mqtt"
 ENV \
   RUST_BACKTRACE=full \
   PATH=/app:$PATH \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,21 +4,6 @@
 FROM --platform=$BUILDPLATFORM alpine:latest AS builder
 ARG TARGETPLATFORM
 
-# Rust und benötigte Tools installieren
-RUN apk add --no-cache build-base openssl-dev curl perl
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-# musl Target hinzufügen
-RUN rustup target add x86_64-unknown-linux-musl
-
-WORKDIR /work
-COPY . .
-
-# Für musl kompilieren
-RUN cargo build --release --target x86_64-unknown-linux-musl
-
-# User wie gehabt anlegen
 RUN adduser \
     --disabled-password \
     --gecos "" \
@@ -28,6 +13,10 @@ RUN adduser \
     --uid "1000" \
     "govee"
 
+WORKDIR /work
+COPY docker-target/$TARGETPLATFORM/govee /work
+
+# Creates an empty /data dir that we can use to copy and chown in the next stage
 WORKDIR /data
 
 ####################################################################################################
@@ -35,13 +24,14 @@ WORKDIR /data
 ####################################################################################################
 FROM gcr.io/distroless/cc-debian12
 
+# Import from builder.
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
+#COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 
 WORKDIR /app
 
-# Das statisch gelinkte musl-Binary kopieren!
-COPY --from=builder /work/target/x86_64-unknown-linux-musl/release/govee /app/govee
+COPY --from=builder /work/govee /app/govee
 COPY AmazonRootCA1.pem /app
 COPY --from=builder --chown=govee:govee /data /data
 COPY assets /app/assets
@@ -60,3 +50,4 @@ CMD ["/app/govee", \
   "--govee-iot-key=/data/iot.key", \
   "--govee-iot-cert=/data/iot.cert", \
   "--amazon-root-ca=/app/AmazonRootCA1.pem"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ COPY --from=builder --chown=govee:govee /data /data
 COPY assets /app/assets
 
 USER govee:govee
-LABEL org.opencontainers.image.source="https://github.com/wez/govee2mqtt"
+LABEL org.opencontainers.image.source="https://github.com/jmerifjKriwe/govee2mqtt"
 ENV \
   RUST_BACKTRACE=full \
   PATH=/app:$PATH \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   govee2mqtt:
-    image: ghcr.io/jmerifjKriwe/govee2mqtt:latest
+    image: ghcr.io/wez/govee2mqtt:latest
     container_name: govee2mqtt
     restart: unless-stopped
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   govee2mqtt:
-    image: ghcr.io/wez/govee2mqtt:latest
+    image: ghcr.io/jmerifjKriwe/govee2mqtt:latest
     container_name: govee2mqtt
     restart: unless-stopped
     env_file:

--- a/src/hass_mqtt/button.rs
+++ b/src/hass_mqtt/button.rs
@@ -5,6 +5,7 @@ use crate::service::device::Device as ServiceDevice;
 use crate::service::hass::{
     availability_topic, camel_case_to_space_separated, topic_safe_id, topic_safe_string, HassClient,
 };
+use crate::service::hass_gc::PublishedEntity;
 use crate::service::state::StateHandle;
 use async_trait::async_trait;
 use serde::Serialize;
@@ -133,7 +134,11 @@ impl ButtonConfig {
 
 #[async_trait]
 impl EntityInstance for ButtonConfig {
-    async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
+    async fn publish_config(
+        &self,
+        state: &StateHandle,
+        client: &HassClient,
+    ) -> anyhow::Result<PublishedEntity> {
         publish_entity_config("button", state, client, &self.base, self).await
     }
 

--- a/src/hass_mqtt/climate.rs
+++ b/src/hass_mqtt/climate.rs
@@ -4,6 +4,7 @@ use crate::hass_mqtt::number::NumberConfig;
 use crate::platform_api::{DeviceCapability, DeviceParameters};
 use crate::service::device::Device as ServiceDevice;
 use crate::service::hass::{availability_topic, topic_safe_id, topic_safe_string, HassClient};
+use crate::service::hass_gc::PublishedEntity;
 use crate::service::state::StateHandle;
 use crate::temperature::{
     TemperatureScale, TemperatureUnits, TemperatureValue, DEVICE_CLASS_TEMPERATURE,
@@ -129,7 +130,11 @@ impl TargetTemperatureEntity {
 
 #[async_trait]
 impl EntityInstance for TargetTemperatureEntity {
-    async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
+    async fn publish_config(
+        &self,
+        state: &StateHandle,
+        client: &HassClient,
+    ) -> anyhow::Result<PublishedEntity> {
         self.number.publish(&state, &client).await
     }
 

--- a/src/hass_mqtt/light.rs
+++ b/src/hass_mqtt/light.rs
@@ -6,6 +6,7 @@ use crate::service::hass::{
     availability_topic, kelvin_to_mired, light_segment_state_topic, light_state_topic,
     topic_safe_id, HassClient,
 };
+use crate::service::hass_gc::PublishedEntity;
 use crate::service::state::StateHandle;
 use async_trait::async_trait;
 use serde::Serialize;
@@ -47,7 +48,11 @@ pub struct LightConfig {
 }
 
 impl LightConfig {
-    pub async fn publish(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
+    pub async fn publish(
+        &self,
+        state: &StateHandle,
+        client: &HassClient,
+    ) -> anyhow::Result<PublishedEntity> {
         publish_entity_config("light", state, client, &self.base, self).await
     }
 }
@@ -61,7 +66,11 @@ pub struct DeviceLight {
 
 #[async_trait]
 impl EntityInstance for DeviceLight {
-    async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
+    async fn publish_config(
+        &self,
+        state: &StateHandle,
+        client: &HassClient,
+    ) -> anyhow::Result<PublishedEntity> {
         self.light.publish(&state, &client).await
     }
 
@@ -109,7 +118,7 @@ impl EntityInstance for DeviceLight {
                 };
 
                 client
-                    .publish_obj(&self.light.state_topic, &light_state)
+                    .publish_obj(&self.light.state_topic, &light_state, false)
                     .await
             }
             None => {
@@ -117,7 +126,7 @@ impl EntityInstance for DeviceLight {
                 // want to prevent attempting to control it though,
                 // as that could cause it to wake up.
                 client
-                    .publish_obj(&self.light.state_topic, &json!({"state":"OFF"}))
+                    .publish_obj(&self.light.state_topic, &json!({ "state": "OFF" }), false)
                     .await
             }
         }

--- a/src/hass_mqtt/scene.rs
+++ b/src/hass_mqtt/scene.rs
@@ -1,6 +1,7 @@
 use crate::hass_mqtt::base::EntityConfig;
 use crate::hass_mqtt::instance::{publish_entity_config, EntityInstance};
 use crate::service::hass::HassClient;
+use crate::service::hass_gc::PublishedEntity;
 use crate::service::state::StateHandle;
 use async_trait::async_trait;
 use serde::Serialize;
@@ -15,14 +16,22 @@ pub struct SceneConfig {
 }
 
 impl SceneConfig {
-    pub async fn publish(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
+    pub async fn publish(
+        &self,
+        state: &StateHandle,
+        client: &HassClient,
+    ) -> anyhow::Result<PublishedEntity> {
         publish_entity_config("scene", state, client, &self.base, self).await
     }
 }
 
 #[async_trait]
 impl EntityInstance for SceneConfig {
-    async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
+    async fn publish_config(
+        &self,
+        state: &StateHandle,
+        client: &HassClient,
+    ) -> anyhow::Result<PublishedEntity> {
         self.publish(&state, &client).await
     }
 

--- a/src/service/hass.rs
+++ b/src/service/hass.rs
@@ -8,6 +8,8 @@ use crate::lan_api::DeviceColor;
 use crate::opt_env_var;
 use crate::platform_api::{from_json, DeviceType};
 use crate::service::device::Device as ServiceDevice;
+use crate::service::hass_gc;
+use crate::service::hass_gc::PublishedEntity;
 use crate::service::state::StateHandle;
 use crate::temperature::TemperatureScale;
 use anyhow::Context;
@@ -15,6 +17,7 @@ use async_channel::Receiver;
 use mosquitto_rs::router::{MqttRouter, Params, Payload, State};
 use mosquitto_rs::{Client, Event, QoS};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -112,12 +115,38 @@ pub struct HassClient {
 }
 
 impl HassClient {
+    async fn garbage_collect_stale_entities(
+        &self,
+        state: &StateHandle,
+        current_entities: &HashSet<PublishedEntity>,
+    ) -> anyhow::Result<()> {
+        let prior_entities = hass_gc::load_published_entities()?;
+
+        let stale_entities = prior_entities.difference(current_entities);
+        let disco_prefix = state.get_hass_disco_prefix().await;
+
+        for entity in stale_entities {
+            let topic = format!(
+                "{disco_prefix}/{integration}/{unique_id}/config",
+                integration = entity.integration,
+                unique_id = entity.unique_id
+            );
+            log::debug!("Removing stale entity by publishing to {topic}");
+            self.publish(topic, "", true).await?;
+        }
+
+        Ok(())
+    }
+
     async fn register_with_hass(&self, state: &StateHandle) -> anyhow::Result<()> {
         let entities = enumerate_all_entites(state).await?;
 
         // Register the configs
         log::trace!("register_with_hass: register entities");
-        entities.publish_config(state, self).await?;
+        let published = entities.publish_config(state, self).await?;
+        self.garbage_collect_stale_entities(state, &published)
+            .await?;
+        hass_gc::save_published_entities(&published)?;
 
         // Allow hass extra time to register the entities before
         // we mark them as available
@@ -130,7 +159,7 @@ impl HassClient {
 
         // Mark as available
         log::trace!("register_with_hass: mark as online");
-        self.publish(availability_topic(), "online")
+        self.publish(availability_topic(), "online", true)
             .await
             .context("online -> availability_topic")?;
 
@@ -147,10 +176,11 @@ impl HassClient {
         &self,
         topic: T,
         payload: P,
+        retain: bool,
     ) -> anyhow::Result<()> {
         log::trace!("{topic} -> {payload}");
         self.client
-            .publish(topic, payload, QoS::AtMostOnce, false)
+            .publish(topic, payload, QoS::AtMostOnce, retain)
             .await?;
         Ok(())
     }
@@ -159,13 +189,10 @@ impl HassClient {
         &self,
         topic: T,
         payload: P,
+        retain: bool,
     ) -> anyhow::Result<()> {
         let payload = serde_json::to_string(&payload)?;
-        log::trace!("{topic} -> {payload}");
-        self.client
-            .publish(topic, payload, QoS::AtMostOnce, false)
-            .await?;
-        Ok(())
+        self.publish(topic, payload, retain).await
     }
 
     pub async fn advise_hass_of_light_state(
@@ -629,7 +656,7 @@ pub async fn spawn_hass_integration(
     let mqtt_password = args.mqtt_password()?;
     let mqtt_port = args.mqtt_port()?;
 
-    client.set_last_will(availability_topic(), "offline", QoS::AtMostOnce, false)?;
+    client.set_last_will(availability_topic(), "offline", QoS::AtMostOnce, true)?;
 
     if mqtt_username.is_some() != mqtt_password.is_some() {
         log::error!(

--- a/src/service/hass_gc.rs
+++ b/src/service/hass_gc.rs
@@ -1,0 +1,39 @@
+use anyhow::anyhow;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+#[derive(Serialize, Deserialize, Debug, Clone, Hash, Eq, PartialEq)]
+pub struct PublishedEntity {
+    pub unique_id: String,
+    pub integration: String,
+}
+
+fn persistence_path() -> anyhow::Result<PathBuf> {
+    let mut path = dirs_next::config_dir()
+        .ok_or_else(|| anyhow!("No config dir found"))?
+        .join("govee2mqtt");
+    std::fs::create_dir_all(&path)?;
+    path.push("hass-entities.json");
+    Ok(path)
+}
+
+pub fn load_published_entities() -> anyhow::Result<HashSet<PublishedEntity>> {
+    let path = persistence_path()?;
+    if !path.exists() {
+        return Ok(HashSet::new());
+    }
+    let data = std::fs::read_to_string(path)?;
+    if data.is_empty() {
+        return Ok(HashSet::new());
+    }
+    let entities: HashSet<PublishedEntity> = serde_json::from_str(&data)?;
+    Ok(entities)
+}
+
+pub fn save_published_entities(entities: &HashSet<PublishedEntity>) -> anyhow::Result<()> {
+    let path = persistence_path()?;
+    let data = serde_json::to_string_pretty(entities)?;
+    std::fs::write(path, data)?;
+    Ok(())
+}

--- a/src/service/hass_gc.rs
+++ b/src/service/hass_gc.rs
@@ -10,8 +10,8 @@ pub struct PublishedEntity {
 }
 
 fn persistence_path() -> anyhow::Result<PathBuf> {
-    let mut path = dirs_next::config_dir()
-        .ok_or_else(|| anyhow!("No config dir found"))?
+    let mut path = dirs_next::cache_dir()
+        .ok_or_else(|| anyhow!("No cache dir found"))?
         .join("govee2mqtt");
     std::fs::create_dir_all(&path)?;
     path.push("hass-entities.json");

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,6 +1,7 @@
 pub mod coordinator;
 pub mod device;
 pub mod hass;
+pub mod hass_gc;
 pub mod http;
 pub mod iot;
 pub mod quirks;


### PR DESCRIPTION
This change implements two key improvements for the Home Assistant MQTT integration:

Retained Discovery Messages: Home Assistant discovery messages for entities are now published with the retain flag set to true. This ensures that entities persist in Home Assistant across restarts of either Home Assistant or the MQTT broker. The availability topic (gv2mqtt/availability) is also now retained.

Stale Entity Garbage Collection: A garbage collection mechanism has been added to automatically remove stale entities from Home Assistant. When govee2mqtt starts, it now:

Loads a list of previously published entities.
Compares it against the current list of entities.
Sends an empty, retained message to the configuration topic for any entity that no longer exists, instructing Home Assistant to remove it.
Saves the new list of published entities for the next run.
This resolves issues where devices could disappear from Home Assistant or where deleted devices would linger.