### PR TITLE
Short circuit logic if offline

### DIFF
--- a/src/hass_mqtt/light.rs
+++ b/src/hass_mqtt/light.rs
@@ -80,6 +80,14 @@ impl EntityInstance for DeviceLight {
             Some(device_state) => {
                 log::trace!("LightConfig::notify_state: state is {device_state:?}");
 
+                if !device_state.online {
+                    client
+                        .publish_obj(&self.light.state_topic, &json!({"state":JsonValue::Null}))
+                        .await;
+                    
+                    return Ok(());
+                }
+
                 let is_on = device_state.light_on.unwrap_or(false);
 
                 let light_state = if is_on {


### PR DESCRIPTION
This should short circuit the logic if the API returns that the light is in an offline state. Should fix https://github.com/wez/govee2mqtt/issues/465