### PR TITLE
Add H66A1 TV Backlight support

### DIFF
--- a/src/service/quirks.rs
+++ b/src/service/quirks.rs
@@ -323,6 +323,7 @@ fn load_quirks() -> HashMap<String, Quirk> {
         Quirk::lan_api_capable_light("H61A8", STRIP),
         Quirk::lan_api_capable_light("H61B2", TV_BACK),
         Quirk::lan_api_capable_light("H61E1", STRIP),
+        Quirk::lan_api_capable_light("H66A1", TV_BACK),
         Quirk::lan_api_capable_light("H7012", STRING),
         Quirk::lan_api_capable_light("H7013", STRING),
         Quirk::lan_api_capable_light("H7021", STRING),


### PR DESCRIPTION
Adds quirk definition for the H66A1 TV Backlight / Light Bar device.

The H66A1 is added as a LAN API capable light with the TV_BACK icon, matching similar TV backlight devices (H6046, H6047, H6168, H61B2).

Closes #565

full disclosure, i had claude help me with this, seems like its a 1 liner but again, i'm no expert in this area and i'm just trying to solve the problem i have with this light (why its not lan capable is annoying but I digress)