### PR TITLE
Fix: remove deprecated brightness/color_mode flags, ensure supported_color_modes is never empty

### DIFF
--- a/src/hass_mqtt/light.rs
+++ b/src/hass_mqtt/light.rs
@@ -24,6 +24,7 @@ pub struct LightConfig {
     pub state_topic: String,
     pub optimistic: bool,
     pub supported_color_modes: Vec<String>,
+    #[serde(skip_serializing)]
     /// Flag that defines if the light supports brightness.
     pub brightness: bool,
     /// Defines the maximum brightness value (i.e., 100%) of the MQTT device.
@@ -82,8 +83,34 @@ impl EntityInstance for DeviceLight {
 
                 let is_on = device_state.light_on.unwrap_or(false);
 
+                // Determine the color_mode to report based on what
+                // this light advertised in supported_color_modes.
+                let has_rgb = self.light.supported_color_modes.iter().any(|m| m == "rgb");
+                let has_color_temp = self.light.supported_color_modes.iter().any(|m| m == "color_temp");
+
                 let light_state = if is_on {
-                    if device_state.kelvin == 0 {
+                    if has_rgb && device_state.kelvin == 0 {
+                        json!({
+                            "state": "ON",
+                            "color_mode": "rgb",
+                            "color": {
+                                "r": device_state.color.r,
+                                "g": device_state.color.g,
+                                "b": device_state.color.b,
+                            },
+                            "brightness": device_state.brightness,
+                            "effect": device_state.scene,
+                        })
+                    } else if has_color_temp && device_state.kelvin > 0 {
+                        json!({
+                            "state": "ON",
+                            "color_mode": "color_temp",
+                            "brightness": device_state.brightness,
+                            "color_temp": kelvin_to_mired(device_state.kelvin),
+                            "effect": device_state.scene,
+                        })
+                    } else if has_rgb {
+                        // Fallback to RGB when we have RGB support
                         json!({
                             "state": "ON",
                             "color_mode": "rgb",
@@ -96,11 +123,12 @@ impl EntityInstance for DeviceLight {
                             "effect": device_state.scene,
                         })
                     } else {
+                        // brightness-only or onoff device
                         json!({
                             "state": "ON",
-                            "color_mode": "color_temp",
+                            "color_mode": self.light.supported_color_modes.first()
+                                .map(|s| s.as_str()).unwrap_or("brightness"),
                             "brightness": device_state.brightness,
-                            "color_temp": kelvin_to_mired(device_state.kelvin),
                             "effect": device_state.scene,
                         })
                     }
@@ -197,6 +225,16 @@ impl DeviceLight {
                 .as_ref()
                 .map(|info| info.supports_brightness())
                 .unwrap_or(false);
+
+        // Ensure supported_color_modes is never empty.
+        // HA 2025.3+ requires this instead of the deprecated brightness flag.
+        if supported_color_modes.is_empty() {
+            if brightness {
+                supported_color_modes.push("brightness".to_string());
+            } else {
+                supported_color_modes.push("onoff".to_string());
+            }
+        }
 
         let name = match segment {
             Some(n) => Some(format!("Segment {:03}", n + 1)),


### PR DESCRIPTION
## Summary

- **Skip serializing** the deprecated `brightness` boolean flag in MQTT discovery payloads (`#[serde(skip_serializing)]`). HA 2025.3+ no longer supports this flag.
- **Ensure `supported_color_modes` is never empty**: when a device only supports brightness (no RGB, no color_temp), `"brightness"` is added; if nothing is supported, `"onoff"` is used as fallback.
- **Adapt `notify_state()`** to only report a `color_mode` in state payloads that matches what was advertised in `supported_color_modes`, preventing the "does not report a color mode" error.

## Problem

Since Home Assistant 2025.3, the deprecated `color_mode` (bool) and `brightness` (bool) flags in MQTT JSON light discovery config are no longer supported. Devices that don't explicitly support RGB or color_temp end up with an empty `supported_color_modes` vector, causing HA to error:

```
light.leselicht (<class 'custom_components.govee.light.GoveeLightEntity'>) does not report a color mode
```

This breaks all automations targeting these lights.

## Changes

| File | Change |
|------|--------|
| `src/hass_mqtt/light.rs` | `#[serde(skip_serializing)]` on `brightness: bool` |
| `src/hass_mqtt/light.rs` | Fallback to `"brightness"` or `"onoff"` when `supported_color_modes` is empty |
| `src/hass_mqtt/light.rs` | `notify_state()` checks `supported_color_modes` before choosing which `color_mode` to report in state |

## Test plan

- [ ] Verify lights with RGB support still work (discovery includes `supported_color_modes: ["rgb"]`)
- [ ] Verify lights with RGB + color_temp still work (discovery includes both)
- [ ] Verify brightness-only lights now report `supported_color_modes: ["brightness"]` instead of empty
- [ ] Verify `light.turn_on` no longer errors with "does not report a color mode"
- [ ] Verify segmented lights (DreamView) still function correctly

Fixes #164, #280, #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)