### PR TITLE
fix: handle multi-byte UTF-8 in camel_case_to_space_separated

### DIFF
--- a/src/service/hass.rs
+++ b/src/service/hass.rs
@@ -696,8 +696,12 @@ pub async fn spawn_hass_integration(
 }
 
 pub fn camel_case_to_space_separated(camel: &str) -> String {
-    let mut result = camel[..1].to_ascii_uppercase();
-    for c in camel.chars().skip(1) {
+    let mut chars = camel.chars();
+    let mut result = match chars.next() {
+        Some(c) => c.to_uppercase().to_string(),
+        None => return String::new(),
+    };
+    for c in chars {
         if c.is_uppercase() {
             result.push(' ');
         }
@@ -714,4 +718,10 @@ fn test_camel_case_to_space_separated() {
         camel_case_to_space_separated("oscillationToggle"),
         "Oscillation Toggle"
     );
+    // Non-ASCII: must not panic on multi-byte UTF-8 characters
+    assert_eq!(
+        camel_case_to_space_separated("用于三灯头中的第二个"),
+        "用于三灯头中的第二个"
+    );
+    assert_eq!(camel_case_to_space_separated(""), "");
 }


### PR DESCRIPTION
## Problem

`camel_case_to_space_separated` in `src/service/hass.rs` uses byte slicing (`camel[..1]`) to extract the first character. This panics on multi-byte UTF-8 input — for example, when a Govee device has Chinese scene/mode names like `用于三灯头中的第二个` ("for the second of three lamp heads").

### Panic message
```
byte index 1 is not a char boundary; it is inside '用' (bytes 0..3) of `用于三灯头中的第二个`
Location: src/service/hass.rs:699
```

This crashes the entire service repeatedly on startup for any user whose Govee account contains devices with non-ASCII metadata.

## Fix

Replace byte slicing with `chars()` iterator to correctly handle all Unicode input. Also handles the empty string edge case.

## Tests

Added test cases for:
- Chinese/multi-byte UTF-8 input (the crash case)
- Empty string input