### PR TITLE
fix: prevent panic on non-ASCII scene names in camel_case_to_space_separated

### DIFF
--- a/src/service/hass.rs
+++ b/src/service/hass.rs
@@ -696,8 +696,16 @@ pub async fn spawn_hass_integration(
 }
 
 pub fn camel_case_to_space_separated(camel: &str) -> String {
-    let mut result = camel[..1].to_ascii_uppercase();
-    for c in camel.chars().skip(1) {
+    if !camel.is_ascii() {
+        return camel.to_string();
+    }
+    let mut chars = camel.chars();
+    let first = match chars.next() {
+        None => return String::new(),
+        Some(c) => c,
+    };
+    let mut result = first.to_ascii_uppercase().to_string();
+    for c in chars {
         if c.is_uppercase() {
             result.push(' ');
         }
@@ -713,5 +721,10 @@ fn test_camel_case_to_space_separated() {
     assert_eq!(
         camel_case_to_space_separated("oscillationToggle"),
         "Oscillation Toggle"
+    );
+    // Non-ASCII strings are not camelCase and must pass through unchanged.
+    assert_eq!(
+        camel_case_to_space_separated("用于三灯头中的第二个"),
+        "用于三灯头中的第二个"
     );
 }


### PR DESCRIPTION
## Problem

Govee devices with non-ASCII scene names cause a panic in `camel_case_to_space_separated`:

```
byte index 1 is not a char boundary; it is inside '用' (bytes 0..3) of `用于三灯头中的第二个`
```

The original implementation used `&camel[..1]` — a byte-level slice that assumes the first character is exactly 1 byte (ASCII). Chinese, Japanese, Arabic and other multi-byte UTF-8 characters are 2–4 bytes wide, so the slice lands inside a character boundary and panics.

### Crash chain

1. govee2mqtt starts → enumerates MQTT entities for all devices
2. A device with non-ASCII scene/instance names (confirmed: **H60B2 Tree Floor Lamp**, segment-specific Chinese names) calls `camel_case_to_space_separated`
3. `&camel[..1]` panics at the char boundary
4. `run_mqtt_loop` closure dies → MQTT connection lost
5. All devices report `MOSQ_ERR_NO_CONN` → nothing controllable in Home Assistant

## Fix

`camelCase` is an ASCII concept. Non-ASCII strings from the Govee API are already human-readable scene names and should be returned as-is.

**Two-layer fix:**

1. **Semantic guard** — `if !camel.is_ascii() { return camel.to_string(); }` makes the intent explicit and short-circuits all further processing for non-ASCII input.
2. **Defensive ASCII path** — replaced `&camel[..1]` byte-slice with `chars().next()` so the implementation is sound regardless of the guard.

## Test added

```rust
// Non-ASCII strings are not camelCase and must pass through unchanged.
assert_eq!(
    camel_case_to_space_separated("用于三灯头中的第二个"),
    "用于三灯头中的第二个"
);
```

`"用于三灯头中的第二个"` is the exact scene name from the H60B2 that triggered the real-world crash. All existing tests continue to pass.