### PR TITLE
fix: missing appVersion header for govee login endpoint

### DIFF
--- a/src/undoc_api.rs
+++ b/src/undoc_api.rs
@@ -209,7 +209,7 @@ impl GoveeUndocumentedApi {
             )
             .header("appVersion", APP_VERSION)
             .header("clientId", &self.client_id)
-            .heer("clientType", "1")
+            .header("clientType", "1")
             .header("iotVersion", "0")
             .header("timestamp", ms_timestamp())
             .header("User-Agent", user_agent())

--- a/src/undoc_api.rs
+++ b/src/undoc_api.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 
 // <https://github.com/constructorfleet/homebridge-ultimate-govee/blob/main/src/data/clients/RestClient.ts>
 
-const APP_VERSION: &str = "5.6.01";
+const APP_VERSION: &str = "6.5.02";
 const HALF_DAY: Duration = Duration::from_secs(3600 * 12);
 const ONE_DAY: Duration = Duration::from_secs(86400);
 const ONE_WEEK: Duration = Duration::from_secs(86400 * 7);
@@ -207,6 +207,12 @@ impl GoveeUndocumentedApi {
                 Method::POST,
                 "https://app2.govee.com/account/rest/account/v1/login",
             )
+            .header("appVersion", APP_VERSION)
+            .header("clientId", &self.client_id)
+            .heer("clientType", "1")
+            .header("iotVersion", "0")
+            .header("timestamp", ms_timestamp())
+            .header("User-Agent", user_agent())
             .json(&serde_json::json!({
                 "email": self.email,
                 "password": self.password,


### PR DESCRIPTION
Govee's login endpoint now rejects requests without an `appVersion` header:
"The app version is too low, please upgrade the version!"                                                                                                                          

Changes:                                                                                                                                                                              
  - Bump `APP_VERSION` from `5.6.01` to `6.5.02` (This change is not required for the fix, but it ensures that the program will function for a longer period of time.)                                                                                                                     
  - Add Govee headers to `login_account_impl()`, matching the pattern used in other functions                                                                                                                                                            

Fixes #622