### PR TITLE
feat: expose scene hint text in SceneCatalogEntry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ on:
       - ".dockerignore"
 
 env:
-  IMAGE: ghcr.io/homeassilol/govee2mqtt
+  IMAGE: ghcr.io/florianhorner/govee2mqtt
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Container Build
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main
@@ -21,7 +22,7 @@ on:
       - ".dockerignore"
 
 env:
-  IMAGE: ghcr.io/wez/govee2mqtt
+  IMAGE: ghcr.io/homeassilol/govee2mqtt
 
 jobs:
   build:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,31 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && github.event.action == 'assigned' && github.event.assignee.login == 'claude[bot]') ||
+      (github.event_name == 'pull_request' && github.event.action == 'assigned' && github.event.assignee.login == 'claude[bot]')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,8 @@ jobs:
     - uses: actions/checkout@v6
     - name: Build
       run: cargo build --all
+    - name: Clippy
+      run: cargo clippy --all -- -D warnings
     - name: Run tests
       run: cargo test --all -- --show-output
     - name: Check formatting

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: local
+    hooks:
+      - id: fmt
+        name: cargo fmt
+        entry: cargo fmt --all -- --check
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: clippy
+        name: cargo clippy
+        entry: cargo clippy --all -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,3 +21,5 @@ cargo fmt --all -- --check
 ## CI
 
 PRs must pass `cargo build`, `cargo test`, and `cargo fmt --check` (see `.github/workflows/pr.yml`).
+
+The fork also runs Claude Code CI (`.github/workflows/claude.yml`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# govee2mqtt
+
+Rust project that bridges Govee smart home devices to MQTT / Home Assistant.
+
+## Build & Test
+
+```bash
+cargo build --all
+cargo test --all -- --show-output
+cargo fmt --all -- --check
+```
+
+## Project Structure
+
+- `src/` — Rust source code
+- `addon/` — Home Assistant add-on configuration
+- `scripts/` — Build and release scripts
+- `docs/` — Documentation
+- `test-data/` — Test fixtures
+
+## CI
+
+PRs must pass `cargo build`, `cargo test`, and `cargo fmt --check` (see `.github/workflows/pr.yml`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ Rust project that bridges Govee smart home devices to MQTT / Home Assistant.
 ```bash
 cargo build --all
 cargo test --all -- --show-output
+cargo clippy --all -- -D warnings
 cargo fmt --all -- --check
 ```
 
@@ -20,6 +21,15 @@ cargo fmt --all -- --check
 
 ## CI
 
-PRs must pass `cargo build`, `cargo test`, and `cargo fmt --check` (see `.github/workflows/pr.yml`).
+PRs must pass `cargo build`, `cargo clippy -- -D warnings`, `cargo test`, and `cargo fmt --check` (see `.github/workflows/pr.yml`).
 
 The fork also runs Claude Code CI (`.github/workflows/claude.yml`).
+
+## Pre-commit Hooks
+
+The repo includes `.pre-commit-config.yaml` with local hooks for `cargo fmt` and `cargo clippy`. To enable:
+
+```bash
+pip install pre-commit
+pre-commit install
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ COPY --from=builder --chown=govee:govee /data /data
 COPY assets /app/assets
 
 USER govee:govee
-LABEL org.opencontainers.image.source="https://github.com/wez/govee2mqtt"
+LABEL org.opencontainers.image.source="https://github.com/homeassilol/govee2mqtt"
 ENV \
   RUST_BACKTRACE=full \
   PATH=/app:$PATH \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ COPY --from=builder --chown=govee:govee /data /data
 COPY assets /app/assets
 
 USER govee:govee
-LABEL org.opencontainers.image.source="https://github.com/homeassilol/govee2mqtt"
+LABEL org.opencontainers.image.source="https://github.com/florianhorner/govee2mqtt"
 ENV \
   RUST_BACKTRACE=full \
   PATH=/app:$PATH \

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ via the [Home Assistant MQTT Integration](https://www.home-assistant.io/integrat
 
 | Commit | File | Change |
 |--------|------|--------|
-| `0070e48` | `src/service/hass.rs` | Replace byte slicing (`camel[..1]`) with char iteration (`chars().next()`) to fix UTF-8 panic on non-ASCII preset names |
-| `dcdf964` | `addon/config.yaml` | Bump version to `2026.03.14-0070e48-patched`, update name/image/url to distinguish from upstream |
+| `624fb96` | `src/service/hass.rs` | Replace byte slicing (`camel[..1]`) with char iteration (`chars().next()`) to fix UTF-8 panic on non-ASCII preset names |
+| `52d0b9c` | `addon/config.yaml`, `.github/`, `README.md` | Brand fork with CI, addon images, version `2026.03.16-44fc86d2`, and config |
 
 **Upstream PR:** [wez/govee2mqtt#606](https://github.com/wez/govee2mqtt/pull/606) by theg1nger
 **Upstream issue:** [wez/govee2mqtt#604](https://github.com/wez/govee2mqtt/issues/604)

--- a/README.md
+++ b/README.md
@@ -14,16 +14,17 @@ via the [Home Assistant MQTT Integration](https://www.home-assistant.io/integrat
 
 | Commit | File | Change |
 |--------|------|--------|
-| `624fb96` | `src/service/hass.rs` | Replace byte slicing (`camel[..1]`) with char iteration (`chars().next()`) to fix UTF-8 panic on non-ASCII preset names |
-| `52d0b9c` | `addon/config.yaml`, `.github/`, `README.md` | Brand fork with CI, addon images, version `2026.03.22-ba238f5e`, and config |
-| `1c1886e` | `.github/workflows/`, tests | Add Claude Code CI, regression tests, and fork fixes |
-| `2df8a4b` | `src/service/quirks.rs` | Add Govee H60B0 (Neon Rope Light 2) as LAN-capable light |
-| `e69fec4` | `src/hass_mqtt/*.rs`, `src/service/hass.rs` | Replace `.expect()` panics with graceful handling; fix silent `exit(0)` → `exit(1)` so HA restarts the addon on failure |
+| `6f2f5cc` | `addon/config.yaml`, `.github/`, `README.md` | Brand fork with CI, addon images, custom addon images, and config |
+| `da4aeb1` | `.github/workflows/`, tests | Add Claude Code CI, regression tests, and fork fixes |
+| `f41ac85` | `src/service/quirks.rs` | Add Govee H60B0 (Neon Rope Light 2) as LAN-capable light |
+| `261eb48` | `src/hass_mqtt/*.rs`, `src/service/hass.rs` | Replace `.expect()` panics with graceful handling; fix silent `exit(0)` → `exit(1)` so HA restarts the addon on failure |
+| `0666c35` | `src/hass_mqtt/*.rs`, `src/service/*.rs` | Scene quick-cycle: Next/Previous buttons, scene info sensor, categorized catalog endpoint with caching |
 
 **Upstream status:**
 - ✅ UTF-8 fix — [merged via #606](https://github.com/wez/govee2mqtt/pull/606) on 2026-03-25
 - ⏳ H60B0 device support — [PR #629](https://github.com/wez/govee2mqtt/pull/629) pending
 - ⏳ Panic hardening + exit code fix — [#617](https://github.com/wez/govee2mqtt/issues/617), [#618](https://github.com/wez/govee2mqtt/issues/618) filed, no PR yet
+- 🆕 Scene quick-cycle buttons + catalog — fork-only feature, not submitted upstream
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,22 @@
+> **⚠️ This is a patched fork of [wez/govee2mqtt](https://github.com/wez/govee2mqtt).**
+> It fixes a UTF-8 crash that causes the bridge to crash-loop when Govee API returns Chinese preset names (affects H6076/H60B2 devices).
+> See [Rollback Instructions](#rollback-to-upstream) below for when to switch back.
+
 # Govee to MQTT bridge for Home Assistant
 
 This repo provides a `govee` executable whose primary purpose is to act
 as a bridge between [Govee](https://govee.com) devices and Home Assistant,
 via the [Home Assistant MQTT Integration](https://www.home-assistant.io/integrations/mqtt/).
+
+## What this fork changes
+
+| Commit | File | Change |
+|--------|------|--------|
+| `0070e48` | `src/service/hass.rs` | Replace byte slicing (`camel[..1]`) with char iteration (`chars().next()`) to fix UTF-8 panic on non-ASCII preset names |
+| `dcdf964` | `addon/config.yaml` | Bump version to `2026.03.14-0070e48-patched`, update name/image/url to distinguish from upstream |
+
+**Upstream PR:** [wez/govee2mqtt#606](https://github.com/wez/govee2mqtt/pull/606) by theg1nger
+**Upstream issue:** [wez/govee2mqtt#604](https://github.com/wez/govee2mqtt/issues/604)
 
 ## Features
 
@@ -43,21 +57,35 @@ via the [Home Assistant MQTT Integration](https://www.home-assistant.io/integrat
 * [Is my device supported?](docs/SKUS.md)
 * [Check out the FAQ](docs/FAQ.md)
 
+## Rollback to upstream
+
+Once [PR #606](https://github.com/wez/govee2mqtt/pull/606) is merged into `wez/govee2mqtt` and a new release is published, switch back to upstream:
+
+1. **Check if the fix is merged:** Visit [wez/govee2mqtt#606](https://github.com/wez/govee2mqtt/pull/606) — if it says "Merged", you're good to go.
+2. **In Home Assistant**, go to **Settings → Add-ons → Add-on Store** (three-dot menu → Repositories).
+3. **Remove** this fork's repo URL: `https://github.com/homeassilol/govee2mqtt`
+4. **Add** the upstream repo URL: `https://github.com/wez/govee2mqtt`
+5. **Refresh** and update/reinstall the Govee2MQTT add-on.
+6. **Restart** the add-on. Verify your Govee devices come back online.
+
+If the upstream release version is newer than `2026.03.14-0070e48-patched`, you know you're on the official build.
+
 ## Want to show your support or gratitude?
 
 It takes significant effort to build, maintain and support users of software
 like this. If you can spare something to say thanks, it is appreciated!
 
-* [Sponsor me on Github](https://github.com/sponsors/wez)
-* [Sponsor me on Patreon](https://patreon.com/WezFurlong)
-* [Sponsor me on Ko-Fi](https://ko-fi.com/wezfurlong)
-* [Sponsor me via liberapay](https://liberapay.com/wez)
+* [Sponsor wez on Github](https://github.com/sponsors/wez)
+* [Sponsor wez on Patreon](https://patreon.com/WezFurlong)
+* [Sponsor wez on Ko-Fi](https://ko-fi.com/wezfurlong)
+* [Sponsor wez via liberapay](https://liberapay.com/wez)
 
 ## Credits
 
-This work is based on my earlier work with [Govee LAN
+This work is based on wez's earlier work with [Govee LAN
 Control](https://github.com/wez/govee-lan-hass/).
 
 The AWS IoT support was made possible by the work of @bwp91 in
 [homebridge-govee](https://github.com/bwp91/homebridge-govee/).
 
+The UTF-8 fix was originally authored by [theg1nger](https://github.com/wez/govee2mqtt/pull/606).

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ via the [Home Assistant MQTT Integration](https://www.home-assistant.io/integrat
 | `f41ac85` | `src/service/quirks.rs` | Add Govee H60B0 (Neon Rope Light 2) as LAN-capable light |
 | `261eb48` | `src/hass_mqtt/*.rs`, `src/service/hass.rs` | Replace `.expect()` panics with graceful handling; fix silent `exit(0)` → `exit(1)` so HA restarts the addon on failure |
 | `0666c35` | `src/hass_mqtt/*.rs`, `src/service/*.rs` | Scene quick-cycle: Next/Previous buttons, scene info sensor, categorized catalog endpoint with caching |
+| `2b87f42` | `.github/workflows/pr.yml`, `.pre-commit-config.yaml`, `src/**` | Add clippy CI gate (`-D warnings`), pre-commit hooks (fmt + clippy), fix all existing clippy warnings |
 
 **Upstream status:**
 - ✅ UTF-8 fix — [merged via #606](https://github.com/wez/govee2mqtt/pull/606) on 2026-03-25

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ via the [Home Assistant MQTT Integration](https://www.home-assistant.io/integrat
 |--------|------|--------|
 | `624fb96` | `src/service/hass.rs` | Replace byte slicing (`camel[..1]`) with char iteration (`chars().next()`) to fix UTF-8 panic on non-ASCII preset names |
 | `52d0b9c` | `addon/config.yaml`, `.github/`, `README.md` | Brand fork with CI, addon images, version `2026.03.16-44fc86d2`, and config |
+| `1c1886e` | `.github/workflows/`, tests | Add Claude Code CI, regression tests, and fork fixes |
+| `2df8a4b` | `src/service/quirks.rs` | Add Govee H60B0 (Neon Rope Light 2) as LAN-capable light |
+| `e69fec4` | `src/hass_mqtt/*.rs`, `src/service/hass.rs` | Replace `.expect()` panics with graceful handling; fix silent `exit(0)` → `exit(1)` so HA restarts the addon on failure |
 
 **Upstream PR:** [wez/govee2mqtt#606](https://github.com/wez/govee2mqtt/pull/606) by theg1nger
 **Upstream issue:** [wez/govee2mqtt#604](https://github.com/wez/govee2mqtt/issues/604)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ via the [Home Assistant MQTT Integration](https://www.home-assistant.io/integrat
 | Commit | File | Change |
 |--------|------|--------|
 | `624fb96` | `src/service/hass.rs` | Replace byte slicing (`camel[..1]`) with char iteration (`chars().next()`) to fix UTF-8 panic on non-ASCII preset names |
-| `52d0b9c` | `addon/config.yaml`, `.github/`, `README.md` | Brand fork with CI, addon images, version `2026.03.22-d384604`, and config |
+| `52d0b9c` | `addon/config.yaml`, `.github/`, `README.md` | Brand fork with CI, addon images, version `2026.03.22-ba238f5e`, and config |
 | `1c1886e` | `.github/workflows/`, tests | Add Claude Code CI, regression tests, and fork fixes |
 | `2df8a4b` | `src/service/quirks.rs` | Add Govee H60B0 (Neon Rope Light 2) as LAN-capable light |
 | `e69fec4` | `src/hass_mqtt/*.rs`, `src/service/hass.rs` | Replace `.expect()` panics with graceful handling; fix silent `exit(0)` → `exit(1)` so HA restarts the addon on failure |
@@ -71,7 +71,7 @@ Once [PR #606](https://github.com/wez/govee2mqtt/pull/606) is merged into `wez/g
 5. **Refresh** and update/reinstall the Govee2MQTT add-on.
 6. **Restart** the add-on. Verify your Govee devices come back online.
 
-If the upstream release version is newer than `2026.03.22-d384604`, you know you're on the official build.
+If the upstream release version is newer than `2026.03.22-ba238f5e`, you know you're on the official build.
 
 ## Want to show your support or gratitude?
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-> **⚠️ This is a patched fork of [wez/govee2mqtt](https://github.com/wez/govee2mqtt).**
-> It fixes a UTF-8 crash that causes the bridge to crash-loop when Govee API returns Chinese preset names (affects H6076/H60B2 devices).
-> See [Rollback Instructions](#rollback-to-upstream) below for when to switch back.
+> **✅ The UTF-8 crash fix has been [merged upstream](https://github.com/wez/govee2mqtt/pull/606) and released as `2026.03.25-ab9deb66`.**
+> If you installed this fork as a workaround, you can now [switch back to upstream](#switch-back-to-upstream).
+>
+> This fork continues as a **maintained community fork** with additional fixes and device support not yet upstream.
+> See [What this fork adds](#what-this-fork-adds) below.
 
 # Govee to MQTT bridge for Home Assistant
 
@@ -8,7 +10,7 @@ This repo provides a `govee` executable whose primary purpose is to act
 as a bridge between [Govee](https://govee.com) devices and Home Assistant,
 via the [Home Assistant MQTT Integration](https://www.home-assistant.io/integrations/mqtt/).
 
-## What this fork changes
+## What this fork adds
 
 | Commit | File | Change |
 |--------|------|--------|
@@ -18,8 +20,10 @@ via the [Home Assistant MQTT Integration](https://www.home-assistant.io/integrat
 | `2df8a4b` | `src/service/quirks.rs` | Add Govee H60B0 (Neon Rope Light 2) as LAN-capable light |
 | `e69fec4` | `src/hass_mqtt/*.rs`, `src/service/hass.rs` | Replace `.expect()` panics with graceful handling; fix silent `exit(0)` → `exit(1)` so HA restarts the addon on failure |
 
-**Upstream PR:** [wez/govee2mqtt#606](https://github.com/wez/govee2mqtt/pull/606) by theg1nger
-**Upstream issue:** [wez/govee2mqtt#604](https://github.com/wez/govee2mqtt/issues/604)
+**Upstream status:**
+- ✅ UTF-8 fix — [merged via #606](https://github.com/wez/govee2mqtt/pull/606) on 2026-03-25
+- ⏳ H60B0 device support — [PR #629](https://github.com/wez/govee2mqtt/pull/629) pending
+- ⏳ Panic hardening + exit code fix — [#617](https://github.com/wez/govee2mqtt/issues/617), [#618](https://github.com/wez/govee2mqtt/issues/618) filed, no PR yet
 
 ## Features
 
@@ -60,18 +64,17 @@ via the [Home Assistant MQTT Integration](https://www.home-assistant.io/integrat
 * [Is my device supported?](docs/SKUS.md)
 * [Check out the FAQ](docs/FAQ.md)
 
-## Rollback to upstream
+## Switch back to upstream
 
-Once [PR #606](https://github.com/wez/govee2mqtt/pull/606) is merged into `wez/govee2mqtt` and a new release is published, switch back to upstream:
+The UTF-8 crash fix is now upstream in release `2026.03.25-ab9deb66`. If you only installed this fork for that fix, you can switch back:
 
-1. **Check if the fix is merged:** Visit [wez/govee2mqtt#606](https://github.com/wez/govee2mqtt/pull/606) — if it says "Merged", you're good to go.
-2. **In Home Assistant**, go to **Settings → Add-ons → Add-on Store** (three-dot menu → Repositories).
-3. **Remove** this fork's repo URL: `https://github.com/homeassilol/govee2mqtt`
-4. **Add** the upstream repo URL: `https://github.com/wez/govee2mqtt`
-5. **Refresh** and update/reinstall the Govee2MQTT add-on.
-6. **Restart** the add-on. Verify your Govee devices come back online.
+1. **In Home Assistant**, go to **Settings → Add-ons → Add-on Store** (three-dot menu → Repositories).
+2. **Remove** this fork's repo URL: `https://github.com/florianhorner/govee2mqtt`
+3. **Add** the upstream repo URL: `https://github.com/wez/govee2mqtt`
+4. **Refresh** and update/reinstall the Govee2MQTT add-on.
+5. **Restart** the add-on. Verify your Govee devices come back online.
 
-If the upstream release version is newer than `2026.03.22-ba238f5e`, you know you're on the official build.
+**Note:** If you want the additional fixes in this fork (H60B0 support, panic hardening, exit code fix), stay on this fork until those are merged upstream.
 
 ## Want to show your support or gratitude?
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ via the [Home Assistant MQTT Integration](https://www.home-assistant.io/integrat
 | Commit | File | Change |
 |--------|------|--------|
 | `624fb96` | `src/service/hass.rs` | Replace byte slicing (`camel[..1]`) with char iteration (`chars().next()`) to fix UTF-8 panic on non-ASCII preset names |
-| `52d0b9c` | `addon/config.yaml`, `.github/`, `README.md` | Brand fork with CI, addon images, version `2026.03.16-44fc86d2`, and config |
+| `52d0b9c` | `addon/config.yaml`, `.github/`, `README.md` | Brand fork with CI, addon images, version `2026.03.22-d384604`, and config |
 | `1c1886e` | `.github/workflows/`, tests | Add Claude Code CI, regression tests, and fork fixes |
 | `2df8a4b` | `src/service/quirks.rs` | Add Govee H60B0 (Neon Rope Light 2) as LAN-capable light |
 | `e69fec4` | `src/hass_mqtt/*.rs`, `src/service/hass.rs` | Replace `.expect()` panics with graceful handling; fix silent `exit(0)` → `exit(1)` so HA restarts the addon on failure |
@@ -71,7 +71,7 @@ Once [PR #606](https://github.com/wez/govee2mqtt/pull/606) is merged into `wez/g
 5. **Refresh** and update/reinstall the Govee2MQTT add-on.
 6. **Restart** the add-on. Verify your Govee devices come back online.
 
-If the upstream release version is newer than `2026.03.14-0070e48-patched`, you know you're on the official build.
+If the upstream release version is newer than `2026.03.22-d384604`, you know you're on the official build.
 
 ## Want to show your support or gratitude?
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,9 @@
+# TODOs
+
+## Cache device_list_scenes() results
+**What:** Make the existing flat `device_list_scenes()` read from the same catalog cache as `device_list_scenes_categorized()`.
+**Why:** The existing function hits the Govee API on every call with no caching, same as the new categorized version. Once the catalog cache exists (Fix #1 in the scene-cycle PR), the flat function should read from it too.
+**Pros:** Fewer API calls globally, consistent behavior, reduces rate-limit risk for all scene interactions.
+**Cons:** Minor additional scope, needs cache invalidation on device re-enumeration.
+**Context:** `state.rs:600` already has a TODO comment: "some plumbing to maintain offline scene controls for preferred-LAN control". This aligns with that goal.
+**Depends on:** Scene Quick-Cycle PR's catalog cache implementation (Fix #1).

--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -502,6 +502,33 @@ Fixes: The app version is too low, please upgrade the version!
 - Fix: correct typo in header method
 - Fix: handle non-ASCII unicode in camel_case_to_space_separated
 
+## [2026.03.22-d384604] - 2026-03-22
+
+### Bug Fixes
+
+- Prevent service crashes from .expect() panics -- replaced with graceful early returns in notify_state across all entity types (climate, humidifier, light, number, select, sensor, switch)
+- Fix silent exit(0) on MQTT loop exit to exit(1) so Home Assistant properly restarts the addon on failure
+
+### Features
+
+- Add Govee H60B0 (Neon Rope Light 2) as LAN-capable light
+
+### Documentation
+
+- Update fork documentation and version references
+
+## [2026.03.16-44fc86d2] - 2026-03-16
+
+### Bug Fixes
+
+- Fix UTF-8 panic in camel_case_to_space_separated -- replace byte slicing with char iteration to handle non-ASCII preset names (Chinese, emoji, etc.)
+
+### Miscellaneous
+
+- Brand fork with CI, addon images, and config
+- Add Claude Code CI workflow and regression tests
+- Add regression tests for Chinese, empty string, and emoji input
+
 ## [2025.11.25-60a39bcc] - 2025-11-25 14:02
 
 ### ⚙️ Miscellaneous

--- a/addon/Dockerfile
+++ b/addon/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILD_FROM
-FROM ghcr.io/wez/govee2mqtt:latest AS govee2mqtt
+FROM ghcr.io/homeassilol/govee2mqtt:latest AS govee2mqtt
 FROM $BUILD_FROM
 COPY run.sh /run.sh
 COPY --from=govee2mqtt /app/govee /app/

--- a/addon/Dockerfile
+++ b/addon/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILD_FROM
-FROM ghcr.io/homeassilol/govee2mqtt:latest AS govee2mqtt
+FROM ghcr.io/florianhorner/govee2mqtt:latest AS govee2mqtt
 FROM $BUILD_FROM
 COPY run.sh /run.sh
 COPY --from=govee2mqtt /app/govee /app/

--- a/addon/build.yaml
+++ b/addon/build.yaml
@@ -1,7 +1,7 @@
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: Govee to MQTT Bridge"
   org.opencontainers.image.description: "Acts as a bridge between Govee devices and Home Assistant, via the Home Assistant MQTT Integration."
-  org.opencontainers.image.source: "https://github.com/wez/govee2mqtt"
+  org.opencontainers.image.source: "https://github.com/homeassilol/govee2mqtt"
   org.opencontainers.image.licenses: "MIT"
 
 # We need to specify these explicitly otherwise :latest will be
@@ -14,7 +14,7 @@ build_from:
 cosign:
   # The identity is *our* identity that we use to sign this image.
   # It is used to verify the safety of reusing the cache
-  identity: https://github.com/wez/govee2mqtt/.*
+  identity: https://github.com/homeassilol/govee2mqtt/.*
   # The base_identity is the identity of the base images specified
   # by the build_from section above
   base_identity: https://github.com/home-assistant/docker-base/.*

--- a/addon/build.yaml
+++ b/addon/build.yaml
@@ -1,7 +1,7 @@
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: Govee to MQTT Bridge"
   org.opencontainers.image.description: "Acts as a bridge between Govee devices and Home Assistant, via the Home Assistant MQTT Integration."
-  org.opencontainers.image.source: "https://github.com/homeassilol/govee2mqtt"
+  org.opencontainers.image.source: "https://github.com/florianhorner/govee2mqtt"
   org.opencontainers.image.licenses: "MIT"
 
 # We need to specify these explicitly otherwise :latest will be
@@ -14,7 +14,7 @@ build_from:
 cosign:
   # The identity is *our* identity that we use to sign this image.
   # It is used to verify the safety of reusing the cache
-  identity: https://github.com/homeassilol/govee2mqtt/.*
+  identity: https://github.com/florianhorner/govee2mqtt/.*
   # The base_identity is the identity of the base images specified
   # by the build_from section above
   base_identity: https://github.com/home-assistant/docker-base/.*

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,5 +1,5 @@
 name: Govee to MQTT Bridge (patched)
-image: ghcr.io/homeassilol/govee2mqtt-{arch}
+image: ghcr.io/florianhorner/govee2mqtt-{arch}
 version: "2026.03.22-ba238f5e"
 slug: govee2mqtt
 description: Control Govee Devices

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,4 +1,5 @@
 name: Govee to MQTT Bridge (patched)
+image: ghcr.io/homeassilol/govee2mqtt-{arch}
 version: "2026.03.16-44fc86d2"
 slug: govee2mqtt
 description: Control Govee Devices

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 name: Govee to MQTT Bridge (patched)
 image: ghcr.io/homeassilol/govee2mqtt-{arch}
-version: "2026.03.22-d384604"
+version: "2026.03.22-ba238f5e"
 slug: govee2mqtt
 description: Control Govee Devices
 url: https://github.com/florianhorner/govee2mqtt

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 name: Govee to MQTT Bridge (patched)
 image: ghcr.io/florianhorner/govee2mqtt-{arch}
-version: "2026.03.22-ba238f5e"
+version: "2026.03.28-cce5dc3c"
 slug: govee2mqtt
 description: Control Govee Devices
 url: https://github.com/florianhorner/govee2mqtt

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 name: Govee to MQTT Bridge (patched)
 image: ghcr.io/homeassilol/govee2mqtt-{arch}
-version: "2026.03.16-44fc86d2"
+version: "2026.03.22-d384604"
 slug: govee2mqtt
 description: Control Govee Devices
 url: https://github.com/florianhorner/govee2mqtt

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,9 +1,8 @@
-name: Govee to MQTT Bridge
-image: ghcr.io/wez/govee2mqtt-{arch}
-version: "2026.03.25-ab9deb66"
+name: Govee to MQTT Bridge (patched)
+version: "2026.03.16-44fc86d2"
 slug: govee2mqtt
 description: Control Govee Devices
-url: https://github.com/wez/govee2mqtt
+url: https://github.com/florianhorner/govee2mqtt
 arch:
   - amd64
   - aarch64

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ fn main() {
             ci_tag = s.trim().to_string();
         }
     } else if let Ok(output) = std::process::Command::new("git")
-        .args(&[
+        .args([
             "-c",
             "core.abbrev=8",
             "show",

--- a/docs/ADDON.md
+++ b/docs/ADDON.md
@@ -54,7 +54,7 @@ when we get to that point.
 
 4. Click on "Repositories"
 5. Enter `https://github.com/wez/govee2mqtt` and click "Add"
-   > **Fork users:** Use `https://github.com/homeassilol/govee2mqtt` instead if you need the patched version with the UTF-8 crash fix.
+   > **Fork users:** Use `https://github.com/florianhorner/govee2mqtt` instead if you need the patched version with the UTF-8 crash fix.
 6. You should see:
 
 ![image](https://github.com/wez/govee-lan-hass/assets/117777/a2603e2d-dec1-4711-8d94-c957bf4a7a01)

--- a/docs/ADDON.md
+++ b/docs/ADDON.md
@@ -54,6 +54,7 @@ when we get to that point.
 
 4. Click on "Repositories"
 5. Enter `https://github.com/wez/govee2mqtt` and click "Add"
+   > **Fork users:** Use `https://github.com/homeassilol/govee2mqtt` instead if you need the patched version with the UTF-8 crash fix.
 6. You should see:
 
 ![image](https://github.com/wez/govee-lan-hass/assets/117777/a2603e2d-dec1-4711-8d94-c957bf4a7a01)

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -43,6 +43,7 @@ TZ=America/Phoenix
 name: govee2mqtt
 services:
   govee2mqtt:
+    # For the patched fork, use: ghcr.io/homeassilol/govee2mqtt:latest
     image: ghcr.io/wez/govee2mqtt:latest
     container_name: govee2mqtt
     restart: unless-stopped

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -43,7 +43,7 @@ TZ=America/Phoenix
 name: govee2mqtt
 services:
   govee2mqtt:
-    # For the patched fork, use: ghcr.io/homeassilol/govee2mqtt:latest
+    # For the patched fork, use: ghcr.io/florianhorner/govee2mqtt:latest
     image: ghcr.io/wez/govee2mqtt:latest
     container_name: govee2mqtt
     restart: unless-stopped

--- a/src/ble.rs
+++ b/src/ble.rs
@@ -17,6 +17,7 @@ impl std::fmt::Debug for HexBytes {
     }
 }
 
+#[allow(clippy::type_complexity)]
 pub struct PacketCodec {
     encode: Box<dyn Fn(&dyn Any) -> anyhow::Result<Vec<u8>> + Sync + Send>,
     decode: Box<dyn Fn(&[u8]) -> anyhow::Result<GoveeBlePacket> + Sync + Send>,
@@ -57,10 +58,10 @@ impl PacketManager {
                 let mut map = HashMap::new();
 
                 for codec in &self.all_codecs {
-                    if codec.supported_skus.iter().any(|s| *s == sku) {
-                        if map.insert(codec.type_id.clone(), codec.clone()).is_some() {
-                            eprintln!("Conflicting PacketCodecs for {sku} {:?}", codec.type_id);
-                        }
+                    if codec.supported_skus.contains(&sku)
+                        && map.insert(codec.type_id, codec.clone()).is_some()
+                    {
+                        eprintln!("Conflicting PacketCodecs for {sku} {:?}", codec.type_id);
                     }
                 }
 
@@ -252,7 +253,7 @@ pub trait DecodePacketParam {
 
 impl DecodePacketParam for u8 {
     fn decode_param<'a>(&mut self, data: &'a [u8]) -> anyhow::Result<&'a [u8]> {
-        *self = *data.get(0).ok_or_else(|| anyhow!("EOF"))?;
+        *self = *data.first().ok_or_else(|| anyhow!("EOF"))?;
         Ok(&data[1..])
     }
 
@@ -263,7 +264,7 @@ impl DecodePacketParam for u8 {
 
 impl DecodePacketParam for u16 {
     fn decode_param<'a>(&mut self, data: &'a [u8]) -> anyhow::Result<&'a [u8]> {
-        let lo = *data.get(0).ok_or_else(|| anyhow!("EOF"))?;
+        let lo = *data.first().ok_or_else(|| anyhow!("EOF"))?;
         let hi = *data.get(1).ok_or_else(|| anyhow!("EOF"))?;
         *self = ((hi as u16) << 8) | lo as u16;
         Ok(&data[2..])
@@ -286,14 +287,14 @@ pub struct SetHumidifierNightlightParams {
     pub brightness: u8,
 }
 
-impl Into<SetHumidifierNightlightParams> for NotifyHumidifierNightlightParams {
-    fn into(self) -> SetHumidifierNightlightParams {
+impl From<NotifyHumidifierNightlightParams> for SetHumidifierNightlightParams {
+    fn from(val: NotifyHumidifierNightlightParams) -> Self {
         SetHumidifierNightlightParams {
-            on: self.on,
-            r: self.r,
-            g: self.g,
-            b: self.b,
-            brightness: self.brightness,
+            on: val.on,
+            r: val.r,
+            g: val.g,
+            b: val.b,
+            brightness: val.brightness,
         }
     }
 }
@@ -312,9 +313,9 @@ pub struct NotifyHumidifierNightlightParams {
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TargetHumidity(u8);
 
-impl Into<u8> for TargetHumidity {
-    fn into(self) -> u8 {
-        self.0
+impl From<TargetHumidity> for u8 {
+    fn from(val: TargetHumidity) -> Self {
+        val.0
     }
 }
 
@@ -381,7 +382,7 @@ impl SetSceneCode {
         let mut last_line_marker = 1;
 
         for b in bytes {
-            if data.len() % 19 == 0 {
+            if data.len().is_multiple_of(19) {
                 num_lines += 1;
 
                 data.push(0xa3);
@@ -478,7 +479,7 @@ impl<'de> Deserialize<'de> for Base64HexBytes {
 fn calculate_checksum(data: &[u8]) -> u8 {
     let mut checksum: u8 = 0;
     for &b in data {
-        checksum = checksum ^ b;
+        checksum ^= b;
     }
     checksum
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -17,7 +17,7 @@ fn cache_file_name() -> PathBuf {
     let cache_dir = std::env::var("GOVEE_CACHE_DIR")
         .ok()
         .map(PathBuf::from)
-        .or_else(|| dirs_next::cache_dir())
+        .or_else(dirs_next::cache_dir)
         .expect("failed to resolve cache dir");
 
     cache_dir.join("govee2mqtt-cache.sqlite")
@@ -26,7 +26,7 @@ fn cache_file_name() -> PathBuf {
 fn open_cache() -> anyhow::Result<Arc<Cache>> {
     let cache_file = cache_file_name();
     let conn = sqlite_cache::rusqlite::Connection::open(&cache_file)
-        .expect(&format!("failed to open {cache_file:?}"));
+        .unwrap_or_else(|_| panic!("failed to open {cache_file:?}"));
     Ok(Arc::new(Cache::new(
         // We have low cardinality and can be pretty relaxed
         CacheConfig {
@@ -42,7 +42,7 @@ pub fn purge_cache() -> anyhow::Result<()> {
     let cache_file = cache_file_name();
     std::fs::remove_file(&cache_file)
         .with_context(|| format!("removing cache file {cache_file:?}"))?;
-    CACHE.store(open_cache()?.into());
+    CACHE.store(open_cache()?);
     Ok(())
 }
 

--- a/src/commands/http_control.rs
+++ b/src/commands/http_control.rs
@@ -94,7 +94,7 @@ impl HttpControlCommand {
                     .ok_or_else(|| anyhow::anyhow!("device has no colorRgb"))?;
                 let [r, g, b, _a] = color.to_rgba8();
                 let value = ((r as u32) << 16) | ((g as u32) << 8) | (b as u32);
-                let result = client.control_device(&device, &cap, value).await?;
+                let result = client.control_device(&device, cap, value).await?;
                 println!("{result:#?}");
             }
 
@@ -188,7 +188,7 @@ impl HttpControlCommand {
                             ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
                         }),
                     });
-                    let result = client.control_device(&device, &cap, value).await?;
+                    let result = client.control_device(&device, cap, value).await?;
                     println!("{result:#?}");
                 }
             }

--- a/src/commands/lan_disco.rs
+++ b/src/commands/lan_disco.rs
@@ -18,7 +18,7 @@ impl LanDiscoCommand {
         let state = crate::service::state::State::new();
 
         while let Ok(Some(lan_device)) = tokio::time::timeout_at(deadline, scan.recv()).await {
-            if !state.device_by_id(&lan_device.device).await.is_some() {
+            if state.device_by_id(&lan_device.device).await.is_none() {
                 let mut device = state.device_mut(&lan_device.sku, &lan_device.device).await;
 
                 device.set_lan_device(lan_device.clone());

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -89,7 +89,7 @@ impl ListCommand {
                 room = d
                     .room_name()
                     .map(|room| format!("({room})"))
-                    .unwrap_or_else(|| String::new()),
+                    .unwrap_or_else(String::new),
             );
         }
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::time::{sleep, Duration};
 
-pub const POLL_INTERVAL: Lazy<chrono::Duration> = Lazy::new(|| chrono::Duration::seconds(900));
+pub static POLL_INTERVAL: Lazy<chrono::Duration> = Lazy::new(|| chrono::Duration::seconds(900));
 
 #[derive(clap::Parser, Debug)]
 pub struct ServeCommand {
@@ -84,13 +84,11 @@ async fn poll_single_device(state: &StateHandle, device: &Device) -> anyhow::Res
         return Ok(());
     }
 
-    if !needs_platform {
-        if state.poll_iot_api(&device).await? {
-            return Ok(());
-        }
+    if !needs_platform && state.poll_iot_api(device).await? {
+        return Ok(());
     }
 
-    state.poll_platform_api(&device).await?;
+    state.poll_platform_api(device).await?;
 
     Ok(())
 }

--- a/src/commands/undoc.rs
+++ b/src/commands/undoc.rs
@@ -8,6 +8,7 @@ pub struct UndocCommand {
 }
 
 #[derive(clap::Parser, Debug)]
+#[allow(clippy::enum_variant_names)]
 enum SubCommand {
     DumpOneClick {},
     ShowOneClick {},
@@ -41,7 +42,7 @@ impl UndocCommand {
                 start_iot_client(&args.undoc_args, state.clone(), None).await?;
                 let iot = state.get_iot_client().await.expect("just started iot");
 
-                iot.activate_one_click(&item).await?;
+                iot.activate_one_click(item).await?;
             }
         }
         Ok(())

--- a/src/hass_mqtt/button.rs
+++ b/src/hass_mqtt/button.rs
@@ -105,6 +105,44 @@ impl ButtonConfig {
         }
     }
 
+    pub fn scene_next_for_device(device: &ServiceDevice) -> Self {
+        let unique_id = format!("gv2mqtt-{id}-scene-next", id = topic_safe_id(device));
+        let command_topic = format!("gv2mqtt/{id}/scene-next", id = topic_safe_id(device));
+        Self {
+            base: EntityConfig {
+                availability_topic: availability_topic(),
+                name: Some("Scene Next".to_string()),
+                entity_category: None,
+                origin: Origin::default(),
+                device: Device::for_device(device),
+                unique_id,
+                device_class: None,
+                icon: Some("mdi:skip-next".to_string()),
+            },
+            command_topic,
+            payload_press: None,
+        }
+    }
+
+    pub fn scene_prev_for_device(device: &ServiceDevice) -> Self {
+        let unique_id = format!("gv2mqtt-{id}-scene-prev", id = topic_safe_id(device));
+        let command_topic = format!("gv2mqtt/{id}/scene-prev", id = topic_safe_id(device));
+        Self {
+            base: EntityConfig {
+                availability_topic: availability_topic(),
+                name: Some("Scene Previous".to_string()),
+                entity_category: None,
+                origin: Origin::default(),
+                device: Device::for_device(device),
+                unique_id,
+                device_class: None,
+                icon: Some("mdi:skip-previous".to_string()),
+            },
+            command_topic,
+            payload_press: None,
+        }
+    }
+
     pub fn request_platform_data_for_device(device: &ServiceDevice) -> Self {
         let unique_id = format!(
             "gv2mqtt-{id}-request-platform-data",

--- a/src/hass_mqtt/climate.rs
+++ b/src/hass_mqtt/climate.rs
@@ -133,11 +133,13 @@ impl EntityInstance for TargetTemperatureEntity {
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
-        let device = self
-            .state
-            .device_by_id(&self.device_id)
-            .await
-            .expect("device to exist");
+        let Some(device) = self.state.device_by_id(&self.device_id).await else {
+            log::warn!(
+                "Device {} not found in state, skipping notify",
+                self.device_id
+            );
+            return Ok(());
+        };
 
         let quirk = device.resolve_quirk();
 

--- a/src/hass_mqtt/climate.rs
+++ b/src/hass_mqtt/climate.rs
@@ -129,7 +129,7 @@ impl TargetTemperatureEntity {
 #[async_trait::async_trait]
 impl EntityInstance for TargetTemperatureEntity {
     async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
-        self.number.publish(&state, &client).await
+        self.number.publish(state, client).await
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
@@ -177,7 +177,7 @@ impl EntityInstance for TargetTemperatureEntity {
 
             log::debug!("setting value to {value}");
 
-            return self.number.notify_state(&client, &value).await;
+            return self.number.notify_state(client, &value).await;
         }
 
         Ok(())

--- a/src/hass_mqtt/enumerator.rs
+++ b/src/hass_mqtt/enumerator.rs
@@ -81,7 +81,7 @@ async fn enumerate_scenes(state: &StateHandle, entities: &mut EntityList) -> any
     Ok(())
 }
 
-async fn entities_for_work_mode<'a>(
+async fn entities_for_work_mode(
     d: &ServiceDevice,
     state: &StateHandle,
     cap: &DeviceCapability,
@@ -146,8 +146,8 @@ async fn entities_for_work_mode<'a>(
     Ok(())
 }
 
-pub async fn enumerate_entities_for_device<'a>(
-    d: &'a ServiceDevice,
+pub async fn enumerate_entities_for_device(
+    d: &ServiceDevice,
     state: &StateHandle,
     entities: &mut EntityList,
 ) -> anyhow::Result<()> {
@@ -166,14 +166,14 @@ pub async fn enumerate_entities_for_device<'a>(
     }
 
     if d.supports_rgb() || d.get_color_temperature_range().is_some() || d.supports_brightness() {
-        entities.add(DeviceLight::for_device(&d, state, None).await?);
+        entities.add(DeviceLight::for_device(d, state, None).await?);
     }
 
     if matches!(
         d.device_type(),
         DeviceType::Humidifier | DeviceType::Dehumidifier
     ) {
-        entities.add(Humidifier::new(&d, state).await?);
+        entities.add(Humidifier::new(d, state).await?);
     }
 
     if d.device_type() != DeviceType::Light {
@@ -186,7 +186,7 @@ pub async fn enumerate_entities_for_device<'a>(
         for cap in &info.capabilities {
             match &cap.kind {
                 DeviceCapabilityKind::Toggle | DeviceCapabilityKind::OnOff => {
-                    entities.add(CapabilitySwitch::new(&d, state, cap).await?);
+                    entities.add(CapabilitySwitch::new(d, state, cap).await?);
                 }
                 DeviceCapabilityKind::ColorSetting
                 | DeviceCapabilityKind::SegmentColorSetting
@@ -202,11 +202,11 @@ pub async fn enumerate_entities_for_device<'a>(
                 }
 
                 DeviceCapabilityKind::Property => {
-                    entities.add(CapabilitySensor::new(&d, state, cap).await?);
+                    entities.add(CapabilitySensor::new(d, state, cap).await?);
                 }
 
                 DeviceCapabilityKind::TemperatureSetting => {
-                    entities.add(TargetTemperatureEntity::new(&d, state, cap).await?);
+                    entities.add(TargetTemperatureEntity::new(d, state, cap).await?);
                 }
 
                 kind => {
@@ -220,7 +220,7 @@ pub async fn enumerate_entities_for_device<'a>(
 
         if let Some(segments) = info.supports_segmented_rgb() {
             for n in segments {
-                entities.add(DeviceLight::for_device(&d, state, Some(n)).await?);
+                entities.add(DeviceLight::for_device(d, state, Some(n)).await?);
             }
         }
     }

--- a/src/hass_mqtt/enumerator.rs
+++ b/src/hass_mqtt/enumerator.rs
@@ -7,7 +7,9 @@ use crate::hass_mqtt::light::DeviceLight;
 use crate::hass_mqtt::number::WorkModeNumber;
 use crate::hass_mqtt::scene::SceneConfig;
 use crate::hass_mqtt::select::{SceneModeSelect, WorkModeSelect};
-use crate::hass_mqtt::sensor::{CapabilitySensor, DeviceStatusDiagnostic, GlobalFixedDiagnostic};
+use crate::hass_mqtt::sensor::{
+    CapabilitySensor, DeviceStatusDiagnostic, GlobalFixedDiagnostic, SceneInfoSensor,
+};
 use crate::hass_mqtt::switch::CapabilitySwitch;
 use crate::hass_mqtt::work_mode::ParsedWorkMode;
 use crate::platform_api::{DeviceCapability, DeviceCapabilityKind, DeviceType};
@@ -155,6 +157,13 @@ pub async fn enumerate_entities_for_device<'a>(
 
     entities.add(DeviceStatusDiagnostic::new(d, state));
     entities.add(ButtonConfig::request_platform_data_for_device(d));
+
+    // Add scene cycling buttons for devices that support scenes
+    if d.supports_rgb() || d.get_color_temperature_range().is_some() {
+        entities.add(ButtonConfig::scene_next_for_device(d));
+        entities.add(ButtonConfig::scene_prev_for_device(d));
+        entities.add(SceneInfoSensor::new(d, state));
+    }
 
     if d.supports_rgb() || d.get_color_temperature_range().is_some() || d.supports_brightness() {
         entities.add(DeviceLight::for_device(&d, state, None).await?);

--- a/src/hass_mqtt/humidifier.rs
+++ b/src/hass_mqtt/humidifier.rs
@@ -103,17 +103,15 @@ impl Humidifier {
 
         if let Some(info) = &device.http_device_info {
             if let Some(cap) = info.capability_by_instance("humidity") {
-                match &cap.parameters {
-                    Some(DeviceParameters::Integer {
-                        range: IntegerRange { min, max, .. },
-                        unit,
-                    }) => {
-                        if unit.as_deref() == Some("unit.percent") {
-                            min_humidity.replace(*min as u8);
-                            max_humidity.replace(*max as u8);
-                        }
+                if let Some(DeviceParameters::Integer {
+                    range: IntegerRange { min, max, .. },
+                    unit,
+                }) = &cap.parameters
+                {
+                    if unit.as_deref() == Some("unit.percent") {
+                        min_humidity.replace(*min as u8);
+                        max_humidity.replace(*max as u8);
                     }
-                    _ => {}
                 }
             }
         }

--- a/src/hass_mqtt/humidifier.rs
+++ b/src/hass_mqtt/humidifier.rs
@@ -170,11 +170,13 @@ impl EntityInstance for Humidifier {
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
-        let device = self
-            .state
-            .device_by_id(&self.device_id)
-            .await
-            .expect("device to exist");
+        let Some(device) = self.state.device_by_id(&self.device_id).await else {
+            log::warn!(
+                "Device {} not found in state, skipping notify",
+                self.device_id
+            );
+            return Ok(());
+        };
 
         match device.device_state() {
             Some(device_state) => {

--- a/src/hass_mqtt/light.rs
+++ b/src/hass_mqtt/light.rs
@@ -62,7 +62,7 @@ pub struct DeviceLight {
 #[async_trait]
 impl EntityInstance for DeviceLight {
     async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
-        self.light.publish(&state, &client).await
+        self.light.publish(state, client).await
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
@@ -157,7 +157,7 @@ impl DeviceLight {
         let unique_id = format!(
             "gv2mqtt-{id}{seg}",
             id = topic_safe_id(device),
-            seg = segment.map(|n| format!("-{n}")).unwrap_or(String::new())
+            seg = segment.map(|n| format!("-{n}")).unwrap_or_default()
         );
 
         let effect_list = if segment.is_some() {

--- a/src/hass_mqtt/light.rs
+++ b/src/hass_mqtt/light.rs
@@ -70,11 +70,13 @@ impl EntityInstance for DeviceLight {
             return Ok(());
         }
 
-        let device = self
-            .state
-            .device_by_id(&self.device_id)
-            .await
-            .expect("device to exist");
+        let Some(device) = self.state.device_by_id(&self.device_id).await else {
+            log::warn!(
+                "Device {} not found in state, skipping notify",
+                self.device_id
+            );
+            return Ok(());
+        };
 
         match device.device_state() {
             Some(device_state) => {

--- a/src/hass_mqtt/number.rs
+++ b/src/hass_mqtt/number.rs
@@ -116,7 +116,7 @@ impl WorkModeNumber {
 #[async_trait]
 impl EntityInstance for WorkModeNumber {
     async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
-        self.number.publish(&state, &client).await
+        self.number.publish(state, client).await
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {

--- a/src/hass_mqtt/number.rs
+++ b/src/hass_mqtt/number.rs
@@ -126,11 +126,13 @@ impl EntityInstance for WorkModeNumber {
             .as_ref()
             .ok_or_else(|| anyhow!("state_topic is None!?"))?;
 
-        let device = self
-            .state
-            .device_by_id(&self.device_id)
-            .await
-            .expect("device to exist");
+        let Some(device) = self.state.device_by_id(&self.device_id).await else {
+            log::warn!(
+                "Device {} not found in state, skipping notify",
+                self.device_id
+            );
+            return Ok(());
+        };
 
         if let Some(cap) = device.get_state_capability_by_instance("workMode") {
             if let Some(work_mode) = cap.state.pointer("/value/workMode") {

--- a/src/hass_mqtt/scene.rs
+++ b/src/hass_mqtt/scene.rs
@@ -23,7 +23,7 @@ impl SceneConfig {
 #[async_trait]
 impl EntityInstance for SceneConfig {
     async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
-        self.publish(&state, &client).await
+        self.publish(state, client).await
     }
 
     async fn notify_state(&self, _client: &HassClient) -> anyhow::Result<()> {

--- a/src/hass_mqtt/select.rs
+++ b/src/hass_mqtt/select.rs
@@ -63,7 +63,7 @@ impl WorkModeSelect {
 #[async_trait::async_trait]
 impl EntityInstance for WorkModeSelect {
     async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
-        self.select.publish(&state, &client).await
+        self.select.publish(state, client).await
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
@@ -144,7 +144,7 @@ impl SceneModeSelect {
 #[async_trait::async_trait]
 impl EntityInstance for SceneModeSelect {
     async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
-        self.select.publish(&state, &client).await
+        self.select.publish(state, client).await
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {

--- a/src/hass_mqtt/select.rs
+++ b/src/hass_mqtt/select.rs
@@ -67,11 +67,13 @@ impl EntityInstance for WorkModeSelect {
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
-        let device = self
-            .state
-            .device_by_id(&self.device_id)
-            .await
-            .expect("device to exist");
+        let Some(device) = self.state.device_by_id(&self.device_id).await else {
+            log::warn!(
+                "Device {} not found in state, skipping notify",
+                self.device_id
+            );
+            return Ok(());
+        };
 
         if let Some(mode_value) = device.humidifier_work_mode {
             if let Ok(work_mode) = ParsedWorkMode::with_device(&device) {
@@ -146,11 +148,13 @@ impl EntityInstance for SceneModeSelect {
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
-        let device = self
-            .state
-            .device_by_id(&self.device_id)
-            .await
-            .expect("device to exist");
+        let Some(device) = self.state.device_by_id(&self.device_id).await else {
+            log::warn!(
+                "Device {} not found in state, skipping notify",
+                self.device_id
+            );
+            return Ok(());
+        };
 
         if let Some(device_state) = device.device_state() {
             client

--- a/src/hass_mqtt/sensor.rs
+++ b/src/hass_mqtt/sensor.rs
@@ -313,3 +313,126 @@ impl EntityInstance for DeviceStatusDiagnostic {
         Ok(())
     }
 }
+
+pub struct SceneInfoSensor {
+    sensor: SensorConfig,
+    device_id: String,
+    device_topic_id: String,
+    state: StateHandle,
+}
+
+impl SceneInfoSensor {
+    pub fn new(device: &ServiceDevice, state: &StateHandle) -> Self {
+        let unique_id = format!("sensor-{id}-gv2mqtt-scene-info", id = topic_safe_id(device));
+
+        Self {
+            device_topic_id: topic_safe_id(device),
+            sensor: SensorConfig {
+                base: EntityConfig {
+                    availability_topic: availability_topic(),
+                    name: Some("Scene Info".to_string()),
+                    entity_category: None,
+                    origin: Origin::default(),
+                    device: Device::for_device(device),
+                    unique_id: unique_id.clone(),
+                    device_class: None,
+                    icon: Some("mdi:palette".to_string()),
+                },
+                state_topic: format!("gv2mqtt/sensor/{unique_id}/state"),
+                state_class: None,
+                json_attributes_topic: Some(format!("gv2mqtt/sensor/{unique_id}/attributes")),
+                unit_of_measurement: None,
+            },
+            device_id: device.id.to_string(),
+            state: state.clone(),
+        }
+    }
+}
+
+#[async_trait]
+impl EntityInstance for SceneInfoSensor {
+    async fn publish_config(
+        &self,
+        state: &StateHandle,
+        client: &HassClient,
+    ) -> anyhow::Result<()> {
+        self.sensor.publish(state, client).await?;
+
+        // Publish scene catalog as retained MQTT message during registration (once),
+        // not on every state change. HA automations can subscribe to this topic.
+        if let Some(device) = self.state.device_by_id(&self.device_id).await {
+            let catalog = self
+                .state
+                .device_list_scenes_categorized(&device)
+                .await
+                .unwrap_or_default();
+            if !catalog.is_empty() {
+                let catalog_topic = format!("gv2mqtt/{}/scene-catalog", self.device_topic_id);
+                if let Err(err) = client.publish_obj_retained(&catalog_topic, &catalog).await {
+                    log::warn!("Failed to publish scene catalog: {err:#}");
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
+        let Some(device) = self.state.device_by_id(&self.device_id).await else {
+            return Ok(());
+        };
+
+        let scene_name = device.active_scene_name().unwrap_or("None").to_string();
+
+        let catalog = self
+            .state
+            .device_list_scenes_categorized(&device)
+            .await
+            .unwrap_or_default();
+
+        // Build flat ordered list for index lookup
+        let flat: Vec<(&str, &str)> = catalog
+            .iter()
+            .flat_map(|cat| {
+                cat.scenes
+                    .iter()
+                    .map(move |s| (s.name.as_str(), cat.name.as_str()))
+            })
+            .collect();
+
+        let current_idx = flat
+            .iter()
+            .position(|(name, _)| name.eq_ignore_ascii_case(&scene_name));
+
+        let (category, index, next_scene, prev_scene) = if let Some(idx) = current_idx {
+            let total = flat.len();
+            let next_idx = (idx + 1) % total;
+            let prev_idx = if idx == 0 { total - 1 } else { idx - 1 };
+            (
+                flat[idx].1.to_string(),
+                idx,
+                flat[next_idx].0.to_string(),
+                flat[prev_idx].0.to_string(),
+            )
+        } else {
+            let next = flat.first().map(|(n, _)| n.to_string()).unwrap_or_default();
+            let prev = flat.last().map(|(n, _)| n.to_string()).unwrap_or_default();
+            ("Unknown".to_string(), 0, next, prev)
+        };
+
+        let attributes = json!({
+            "scene_name": scene_name,
+            "category": category,
+            "index": index,
+            "total": flat.len(),
+            "next_scene": next_scene,
+            "prev_scene": prev_scene,
+        });
+
+        self.sensor.notify_state(client, &scene_name).await?;
+        if let Some(topic) = &self.sensor.json_attributes_topic {
+            client.publish_obj(topic, attributes).await?;
+        }
+        Ok(())
+    }
+}

--- a/src/hass_mqtt/sensor.rs
+++ b/src/hass_mqtt/sensor.rs
@@ -57,11 +57,11 @@ pub struct GlobalFixedDiagnostic {
 #[async_trait]
 impl EntityInstance for GlobalFixedDiagnostic {
     async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
-        self.sensor.publish(&state, &client).await
+        self.sensor.publish(state, client).await
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
-        self.sensor.notify_state(&client, &self.value).await
+        self.sensor.notify_state(client, &self.value).await
     }
 }
 
@@ -150,7 +150,7 @@ impl CapabilitySensor {
                     icon: None,
                 },
                 state_topic: format!("gv2mqtt/sensor/{unique_id}/state"),
-                state_class: state_class,
+                state_class,
                 unit_of_measurement,
                 json_attributes_topic: None,
             },
@@ -164,7 +164,7 @@ impl CapabilitySensor {
 #[async_trait]
 impl EntityInstance for CapabilitySensor {
     async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
-        self.sensor.publish(&state, &client).await
+        self.sensor.publish(state, client).await
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
@@ -208,7 +208,7 @@ impl EntityInstance for CapabilitySensor {
                         .state
                         .pointer("/value")
                         .and_then(|v| v.as_f64())
-                        .map(|v| units.from_reading_to_relative_percent(v))
+                        .map(|v| units.reading_to_relative_percent(v))
                     {
                         Some(v) => format!("{v:.2}"),
                         None => "".to_string(),
@@ -217,7 +217,7 @@ impl EntityInstance for CapabilitySensor {
                 _ => cap.state.to_string(),
             };
 
-            return self.sensor.notify_state(&client, &value).await;
+            return self.sensor.notify_state(client, &value).await;
         }
         log::trace!(
             "CapabilitySensor::notify_state: didn't find state for {device} {instance}",
@@ -263,7 +263,7 @@ impl DeviceStatusDiagnostic {
 #[async_trait]
 impl EntityInstance for DeviceStatusDiagnostic {
     async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
-        self.sensor.publish(&state, &client).await
+        self.sensor.publish(state, client).await
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
@@ -306,7 +306,7 @@ impl EntityInstance for DeviceStatusDiagnostic {
             "overall": device_state,
         });
 
-        self.sensor.notify_state(&client, &summary).await?;
+        self.sensor.notify_state(client, &summary).await?;
         if let Some(topic) = &self.sensor.json_attributes_topic {
             client.publish_obj(topic, attributes).await?;
         }
@@ -351,11 +351,7 @@ impl SceneInfoSensor {
 
 #[async_trait]
 impl EntityInstance for SceneInfoSensor {
-    async fn publish_config(
-        &self,
-        state: &StateHandle,
-        client: &HassClient,
-    ) -> anyhow::Result<()> {
+    async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
         self.sensor.publish(state, client).await?;
 
         // Publish scene catalog as retained MQTT message during registration (once),

--- a/src/hass_mqtt/sensor.rs
+++ b/src/hass_mqtt/sensor.rs
@@ -168,11 +168,13 @@ impl EntityInstance for CapabilitySensor {
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
-        let device = self
-            .state
-            .device_by_id(&self.device_id)
-            .await
-            .expect("device to exist");
+        let Some(device) = self.state.device_by_id(&self.device_id).await else {
+            log::warn!(
+                "Device {} not found in state, skipping notify",
+                self.device_id
+            );
+            return Ok(());
+        };
 
         let quirk = device.resolve_quirk();
 
@@ -265,11 +267,13 @@ impl EntityInstance for DeviceStatusDiagnostic {
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
-        let device = self
-            .state
-            .device_by_id(&self.device_id)
-            .await
-            .expect("device to exist");
+        let Some(device) = self.state.device_by_id(&self.device_id).await else {
+            log::warn!(
+                "Device {} not found in state, skipping notify",
+                self.device_id
+            );
+            return Ok(());
+        };
 
         let iot_state = device.compute_iot_device_state();
         let lan_state = device.compute_lan_device_state();

--- a/src/hass_mqtt/switch.rs
+++ b/src/hass_mqtt/switch.rs
@@ -84,7 +84,7 @@ impl CapabilitySwitch {
 #[async_trait]
 impl EntityInstance for CapabilitySwitch {
     async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
-        self.switch.publish(&state, &client).await
+        self.switch.publish(state, client).await
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {

--- a/src/hass_mqtt/switch.rs
+++ b/src/hass_mqtt/switch.rs
@@ -88,11 +88,13 @@ impl EntityInstance for CapabilitySwitch {
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
-        let device = self
-            .state
-            .device_by_id(&self.device_id)
-            .await
-            .expect("device to exist");
+        let Some(device) = self.state.device_by_id(&self.device_id).await else {
+            log::warn!(
+                "Device {} not found in state, skipping notify",
+                self.device_id
+            );
+            return Ok(());
+        };
 
         if self.instance_name == "powerSwitch" {
             if let Some(state) = device.device_state() {

--- a/src/hass_mqtt/work_mode.rs
+++ b/src/hass_mqtt/work_mode.rs
@@ -32,26 +32,20 @@ impl ParsedWorkMode {
             .struct_field_by_name("workMode")
             .ok_or_else(|| anyhow!("workMode not found in {cap:?}"))?;
 
-        match &wm.field_type {
-            DeviceParameters::Enum { options } => {
-                for opt in options {
-                    work_modes.add(opt.name.to_string(), opt.value.clone());
-                }
+        if let DeviceParameters::Enum { options } = &wm.field_type {
+            for opt in options {
+                work_modes.add(opt.name.to_string(), opt.value.clone());
             }
-            _ => {}
         }
 
         if let Some(mv) = cap.struct_field_by_name("modeValue") {
-            match &mv.field_type {
-                DeviceParameters::Enum { options } => {
-                    for opt in options {
-                        let mode_name = &opt.name;
-                        if let Some(work_mode) = work_modes.get_mut(mode_name) {
-                            work_mode.add_values(opt);
-                        }
+            if let DeviceParameters::Enum { options } = &mv.field_type {
+                for opt in options {
+                    let mode_name = &opt.name;
+                    if let Some(work_mode) = work_modes.get_mut(mode_name) {
+                        work_mode.add_values(opt);
                     }
                 }
-                _ => {}
             }
         }
         Ok(work_modes)
@@ -75,19 +69,19 @@ impl ParsedWorkMode {
     pub fn adjust_for_device(&mut self, sku: &str) {
         match sku {
             "H7160" | "H7143" => {
-                self.modes
-                    .get_mut("Manual")
-                    .map(|m| m.label = "Manual: Mist Level".to_string());
+                if let Some(m) = self.modes.get_mut("Manual") {
+                    m.label = "Manual: Mist Level".to_string();
+                }
             }
             "H7131" => {
-                self.modes.get_mut("gearMode").map(|m| {
+                if let Some(m) = self.modes.get_mut("gearMode") {
                     m.label = "Heat".to_string();
-                });
+                }
             }
             "H7173" => {
-                self.modes.get_mut("gearMode").map(|m| {
+                if let Some(m) = self.modes.get_mut("gearMode") {
                     m.label = "Heat".to_string();
-                });
+                }
             }
             _ => {
                 for mode in self.modes.values_mut() {
@@ -98,12 +92,10 @@ impl ParsedWorkMode {
     }
 
     pub fn mode_for_value(&self, value: &JsonValue) -> Option<&WorkMode> {
-        for mode in self.modes.values() {
-            if mode.value == *value {
-                return Some(mode);
-            }
-        }
-        None
+        self.modes
+            .values()
+            .find(|&mode| mode.value == *value)
+            .map(|v| v as _)
     }
 
     pub fn mode_by_name(&self, name: &str) -> Option<&WorkMode> {
@@ -112,12 +104,10 @@ impl ParsedWorkMode {
 
     #[allow(unused)]
     pub fn mode_by_label(&self, name: &str) -> Option<&WorkMode> {
-        for mode in self.modes.values() {
-            if mode.label() == name {
-                return Some(mode);
-            }
-        }
-        None
+        self.modes
+            .values()
+            .find(|&mode| mode.label() == name)
+            .map(|v| v as _)
     }
 
     pub fn get_mode_names(&self) -> Vec<String> {
@@ -143,13 +133,7 @@ impl ParsedWorkMode {
 
     #[allow(unused)]
     pub fn modes_with_values(&self) -> impl Iterator<Item = &WorkMode> {
-        self.modes.values().filter_map(|mode| {
-            if mode.values.is_empty() {
-                None
-            } else {
-                Some(mode)
-            }
-        })
+        self.modes.values().filter(|mode| !mode.values.is_empty())
     }
 }
 
@@ -237,7 +221,7 @@ impl WorkMode {
         self.default_value
             .as_ref()
             .and_then(|v| v.as_i64())
-            .or_else(|| self.values.get(0).and_then(|wmv| wmv.value.as_i64()))
+            .or_else(|| self.values.first().and_then(|wmv| wmv.value.as_i64()))
             .or_else(|| self.value_range.as_ref().map(|r| r.start))
             .unwrap_or(0)
     }
@@ -267,7 +251,7 @@ impl WorkMode {
             if item != expect {
                 return None;
             }
-            expect = expect + 1;
+            expect += 1;
         }
 
         Some(min..max + 1)

--- a/src/platform_api.rs
+++ b/src/platform_api.rs
@@ -229,8 +229,8 @@ impl GoveeApiClient {
     ) -> anyhow::Result<Vec<DeviceCapability>> {
         let mut result = vec![];
 
-        let scene_caps = self.get_device_scenes(&device).await?;
-        let diy_caps = self.get_device_diy_scenes(&device).await?;
+        let scene_caps = self.get_device_scenes(device).await?;
+        let diy_caps = self.get_device_diy_scenes(device).await?;
         let undoc_caps =
             match GoveeUndocumentedApi::synthesize_platform_api_scene_list(&device.sku).await {
                 Ok(caps) => caps,
@@ -303,13 +303,10 @@ impl GoveeApiClient {
             if let Some(DeviceParameters::Struct { fields }) = &cap.parameters {
                 for f in fields {
                     if f.field_name == "musicMode" {
-                        match &f.field_type {
-                            DeviceParameters::Enum { options } => {
-                                for opt in options {
-                                    result.push(format!("Music: {}", opt.name));
-                                }
+                        if let DeviceParameters::Enum { options } = &f.field_type {
+                            for opt in options {
+                                result.push(format!("Music: {}", opt.name));
                             }
-                            _ => {}
                         }
                     }
                 }
@@ -328,7 +325,7 @@ impl GoveeApiClient {
         device: &HttpDeviceInfo,
         scene: &str,
     ) -> anyhow::Result<ControlDeviceResponseCapability> {
-        if scene == "" {
+        if scene.is_empty() {
             // Can't set no scene
             anyhow::bail!("Cannot set scene to no-scene");
         }
@@ -342,7 +339,7 @@ impl GoveeApiClient {
                             "sensitivity": 100,
                             "autoColor": 1,
                         });
-                        return self.control_device(&device, &cap, value).await;
+                        return self.control_device(device, cap, value).await;
                     }
                 }
             }
@@ -354,7 +351,7 @@ impl GoveeApiClient {
                 Some(DeviceParameters::Enum { options }) => {
                     for opt in options {
                         if scene.eq_ignore_ascii_case(&opt.name) {
-                            return self.control_device(&device, &cap, opt.value.clone()).await;
+                            return self.control_device(device, &cap, opt.value.clone()).await;
                         }
                     }
                 }
@@ -392,7 +389,7 @@ impl GoveeApiClient {
             "unit": "Celsius",
         });
 
-        self.control_device(&device, &cap, value).await
+        self.control_device(device, cap, value).await
     }
 
     pub async fn set_work_mode(
@@ -410,7 +407,7 @@ impl GoveeApiClient {
             "modeValue": value
         });
 
-        self.control_device(&device, &cap, value).await
+        self.control_device(device, cap, value).await
     }
 
     pub async fn set_toggle_state(
@@ -427,7 +424,7 @@ impl GoveeApiClient {
             .enum_parameter_by_name(if on { "on" } else { "off" })
             .ok_or_else(|| anyhow::anyhow!("{instance} has no on/off!?"))?;
 
-        self.control_device(&device, &cap, value).await
+        self.control_device(device, cap, value).await
     }
 
     pub async fn set_power_state(
@@ -453,7 +450,7 @@ impl GoveeApiClient {
             }) => (percent as u32).max(*min).min(*max),
             _ => anyhow::bail!("unexpected parameter type for brightness"),
         };
-        self.control_device(&device, &cap, value).await
+        self.control_device(device, cap, value).await
     }
 
     pub async fn set_color_temperature(
@@ -471,7 +468,7 @@ impl GoveeApiClient {
             }) => (kelvin).max(*min).min(*max),
             _ => anyhow::bail!("unexpected parameter type for colorTemperatureK"),
         };
-        self.control_device(&device, &cap, value).await
+        self.control_device(device, cap, value).await
     }
 
     pub async fn set_color_rgb(
@@ -485,7 +482,7 @@ impl GoveeApiClient {
             .capability_by_instance("colorRgb")
             .ok_or_else(|| anyhow::anyhow!("device has no colorRgb"))?;
         let value = ((r as u32) << 16) | ((g as u32) << 8) | (b as u32);
-        self.control_device(&device, &cap, value).await
+        self.control_device(device, cap, value).await
     }
 
     pub async fn set_segment_rgb(
@@ -501,8 +498,8 @@ impl GoveeApiClient {
             .ok_or_else(|| anyhow::anyhow!("device has no segmentedColorRgb"))?;
         let value = ((r as u32) << 16) | ((g as u32) << 8) | (b as u32);
         self.control_device(
-            &device,
-            &cap,
+            device,
+            cap,
             json!({
                 "segment": vec![segment],
                 "rgb": value,
@@ -528,8 +525,8 @@ impl GoveeApiClient {
         let value = (percent as u32).max(min).min(max);
 
         self.control_device(
-            &device,
-            &cap,
+            device,
+            cap,
             json!({
                 "segment": vec![segment],
                 "brightness": value,

--- a/src/service/device.rs
+++ b/src/service/device.rs
@@ -305,7 +305,6 @@ impl Device {
         for cap in &state.capabilities {
             if let Ok(value) = serde_json::from_value::<IntegerValueState>(cap.state.clone()) {
                 if light_instance
-                    .as_deref()
                     .map(|inst| inst == cap.instance.as_str())
                     .unwrap_or(false)
                 {
@@ -457,11 +456,10 @@ impl Device {
             return false;
         }
         let device_type = self.device_type();
-        match (device_type, self.sku.as_str()) {
-            (_, "H7160") => true,
-            (DeviceType::Light, _) => true,
-            _ => false,
-        }
+        matches!(
+            (device_type, self.sku.as_str()),
+            (_, "H7160") | (DeviceType::Light, _)
+        )
     }
 
     pub fn avoid_platform_api(&self) -> bool {
@@ -605,19 +603,13 @@ impl Device {
             return Some(false);
         }
 
-        if let Some(info) = &self.undoc_device_info {
-            Some(info.entry.device_ext.device_settings.wifi_name.is_none())
-        } else {
-            // Don't know for sure
-            None
-        }
+        self.undoc_device_info
+            .as_ref()
+            .map(|info| info.entry.device_ext.device_settings.wifi_name.is_none())
     }
 
     pub fn is_controllable(&self) -> bool {
-        match self.is_ble_only_device() {
-            Some(true) => false,
-            _ => true,
-        }
+        !matches!(self.is_ble_only_device(), Some(true))
     }
 }
 

--- a/src/service/device.rs
+++ b/src/service/device.rs
@@ -5,6 +5,7 @@ use crate::platform_api::{
     DeviceCapability, DeviceCapabilityState, DeviceType, HttpDeviceInfo, HttpDeviceState,
 };
 use crate::service::quirks::{resolve_quirk, Quirk, BULB};
+use crate::service::state::SceneCatalogCategory;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -44,6 +45,8 @@ pub struct Device {
     pub last_polled: Option<DateTime<Utc>>,
 
     active_scene: Option<ActiveSceneInfo>,
+    /// Cached scene catalog to avoid repeated API calls during state notifications
+    scene_catalog_cache: Option<Vec<SceneCatalogCategory>>,
 }
 
 impl std::fmt::Display for Device {
@@ -365,6 +368,21 @@ impl Device {
         candidates.sort_by(|a, b| a.updated.cmp(&b.updated));
 
         candidates.pop()
+    }
+
+    /// Returns the active scene name, if any
+    pub fn active_scene_name(&self) -> Option<&str> {
+        self.active_scene.as_ref().map(|s| s.name.as_str())
+    }
+
+    /// Returns the cached scene catalog, if available
+    pub fn scene_catalog(&self) -> Option<&Vec<SceneCatalogCategory>> {
+        self.scene_catalog_cache.as_ref()
+    }
+
+    /// Caches the scene catalog for this device
+    pub fn set_scene_catalog(&mut self, catalog: Vec<SceneCatalogCategory>) {
+        self.scene_catalog_cache = Some(catalog);
     }
 
     /// Records the active scene name

--- a/src/service/hass.rs
+++ b/src/service/hass.rs
@@ -687,8 +687,10 @@ pub async fn spawn_hass_integration(
             tokio::time::sleep(tokio::time::Duration::from_secs(30)).await;
             std::process::exit(1);
         } else {
-            log::info!("run_mqtt_loop exited. We should do something to shutdown gracefully here");
-            std::process::exit(0);
+            log::error!(
+                "run_mqtt_loop exited unexpectedly. Terminating so HA can restart the addon."
+            );
+            std::process::exit(1);
         }
     });
 

--- a/src/service/hass.rs
+++ b/src/service/hass.rs
@@ -715,7 +715,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_camel_case_to_space_separated() {
+    fn test_camel_case_ascii() {
         assert_eq!(camel_case_to_space_separated("powerSwitch"), "Power Switch");
         assert_eq!(
             camel_case_to_space_separated("oscillationToggle"),

--- a/src/service/hass.rs
+++ b/src/service/hass.rs
@@ -168,6 +168,19 @@ impl HassClient {
         Ok(())
     }
 
+    pub async fn publish_obj_retained<T: AsRef<str> + std::fmt::Display, P: Serialize>(
+        &self,
+        topic: T,
+        payload: P,
+    ) -> anyhow::Result<()> {
+        let payload = serde_json::to_string(&payload)?;
+        log::trace!("{topic} -> {payload} (retained)");
+        self.client
+            .publish(topic, payload, QoS::AtMostOnce, true)
+            .await?;
+        Ok(())
+    }
+
     pub async fn advise_hass_of_light_state(
         &self,
         device: &ServiceDevice,
@@ -235,6 +248,76 @@ pub fn purge_cache_topic() -> String {
 #[derive(Deserialize)]
 pub struct IdParameter {
     pub id: String,
+}
+
+/// Someone pressed the "Scene Next" button
+async fn mqtt_scene_next(
+    Params(IdParameter { id }): Params<IdParameter>,
+    State(state): State<StateHandle>,
+) -> anyhow::Result<()> {
+    scene_cycle(&state, &id, 1).await
+}
+
+/// Someone pressed the "Scene Previous" button
+async fn mqtt_scene_prev(
+    Params(IdParameter { id }): Params<IdParameter>,
+    State(state): State<StateHandle>,
+) -> anyhow::Result<()> {
+    scene_cycle(&state, &id, -1).await
+}
+
+/// Computes the target scene index for cycling.
+/// Returns the index into `scenes` to activate.
+fn compute_scene_cycle_index(
+    scenes: &[String],
+    current_name: Option<&str>,
+    direction: i32,
+) -> usize {
+    let total = scenes.len() as i32;
+    match current_name.and_then(|name| scenes.iter().position(|n| n.eq_ignore_ascii_case(name))) {
+        Some(idx) => ((idx as i32 + direction).rem_euclid(total)) as usize,
+        None => {
+            if direction > 0 {
+                0
+            } else {
+                (total - 1) as usize
+            }
+        }
+    }
+}
+
+/// Shared logic for scene next/prev cycling
+async fn scene_cycle(state: &StateHandle, id: &str, direction: i32) -> anyhow::Result<()> {
+    // Acquire Coordinator first to prevent races with concurrent scene changes
+    let coord = state.resolve_device_for_control(id).await?;
+
+    let catalog = state.device_list_scenes_categorized(&coord).await?;
+    let flat: Vec<String> = catalog
+        .into_iter()
+        .flat_map(|cat| cat.scenes.into_iter().map(|s| s.name))
+        .collect();
+
+    if flat.is_empty() {
+        anyhow::bail!("No scenes available for device {id}");
+    }
+
+    let current_name = coord.active_scene_name().map(|s| s.to_string());
+    let new_idx = compute_scene_cycle_index(&flat, current_name.as_deref(), direction);
+
+    let target_scene = &flat[new_idx];
+
+    log::info!(
+        "Scene cycle {}: {} -> {} (index {} of {})",
+        if direction > 0 { "next" } else { "prev" },
+        current_name.as_deref().unwrap_or("None"),
+        target_scene,
+        new_idx,
+        flat.len()
+    );
+
+    state.device_set_scene(&coord, target_scene).await?;
+
+    Ok(())
 }
 
 /// Someone clicked the "Request Platform API State" button
@@ -542,6 +625,12 @@ async fn run_mqtt_loop(
             )
             .await?;
         router
+            .route("gv2mqtt/:id/scene-next", mqtt_scene_next)
+            .await?;
+        router
+            .route("gv2mqtt/:id/scene-prev", mqtt_scene_prev)
+            .await?;
+        router
             .route(
                 "gv2mqtt/number/:id/command/:mode_name/:work_mode",
                 mqtt_number_command,
@@ -741,5 +830,63 @@ mod tests {
     #[test]
     fn test_camel_case_emoji() {
         assert_eq!(camel_case_to_space_separated("🔥lightMode"), "🔥light Mode");
+    }
+
+    #[test]
+    fn test_scene_cycle_next_from_middle() {
+        let scenes: Vec<String> = vec!["A".into(), "B".into(), "C".into()];
+        assert_eq!(compute_scene_cycle_index(&scenes, Some("B"), 1), 2);
+    }
+
+    #[test]
+    fn test_scene_cycle_prev_from_middle() {
+        let scenes: Vec<String> = vec!["A".into(), "B".into(), "C".into()];
+        assert_eq!(compute_scene_cycle_index(&scenes, Some("B"), -1), 0);
+    }
+
+    #[test]
+    fn test_scene_cycle_next_wraps_last_to_first() {
+        let scenes: Vec<String> = vec!["A".into(), "B".into(), "C".into()];
+        assert_eq!(compute_scene_cycle_index(&scenes, Some("C"), 1), 0);
+    }
+
+    #[test]
+    fn test_scene_cycle_prev_wraps_first_to_last() {
+        let scenes: Vec<String> = vec!["A".into(), "B".into(), "C".into()];
+        assert_eq!(compute_scene_cycle_index(&scenes, Some("A"), -1), 2);
+    }
+
+    #[test]
+    fn test_scene_cycle_no_active_scene_next() {
+        let scenes: Vec<String> = vec!["A".into(), "B".into(), "C".into()];
+        assert_eq!(compute_scene_cycle_index(&scenes, None, 1), 0);
+    }
+
+    #[test]
+    fn test_scene_cycle_no_active_scene_prev() {
+        let scenes: Vec<String> = vec!["A".into(), "B".into(), "C".into()];
+        assert_eq!(compute_scene_cycle_index(&scenes, None, -1), 2);
+    }
+
+    #[test]
+    fn test_scene_cycle_case_insensitive() {
+        let scenes: Vec<String> = vec!["Sunset".into(), "Rainbow".into()];
+        assert_eq!(compute_scene_cycle_index(&scenes, Some("sunset"), 1), 1);
+    }
+
+    #[test]
+    fn test_scene_cycle_single_scene() {
+        let scenes: Vec<String> = vec!["Only".into()];
+        assert_eq!(compute_scene_cycle_index(&scenes, Some("Only"), 1), 0);
+        assert_eq!(compute_scene_cycle_index(&scenes, Some("Only"), -1), 0);
+    }
+
+    #[test]
+    fn test_scene_cycle_unknown_scene_treated_as_no_active() {
+        let scenes: Vec<String> = vec!["A".into(), "B".into()];
+        assert_eq!(
+            compute_scene_cycle_index(&scenes, Some("nonexistent"), 1),
+            0
+        );
     }
 }

--- a/src/service/hass.rs
+++ b/src/service/hass.rs
@@ -454,7 +454,7 @@ async fn mqtt_light_segment_command(
 
         if let Some(brightness) = command.brightness {
             client
-                .set_segment_brightness(&info, segment, brightness)
+                .set_segment_brightness(info, segment, brightness)
                 .await?;
         } else if command.state == "OFF" {
             // Do nothing here. We used to set brightness to zero,
@@ -468,7 +468,7 @@ async fn mqtt_light_segment_command(
         }
         if let Some(color) = &command.color {
             client
-                .set_segment_rgb(&info, segment, color.r, color.g, color.b)
+                .set_segment_rgb(info, segment, color.r, color.g, color.b)
                 .await?;
         }
     } else {
@@ -511,7 +511,7 @@ async fn mqtt_oneclick(
         .await
         .ok_or_else(|| anyhow::anyhow!("AWS IoT client is not available"))?;
 
-    iot.activate_one_click(&item).await
+    iot.activate_one_click(item).await
 }
 
 #[derive(Deserialize)]
@@ -663,7 +663,7 @@ async fn run_mqtt_loop(
             .get_hass_client()
             .await
             .expect("have hass client")
-            .register_with_hass(&state)
+            .register_with_hass(state)
             .await
             .context("register_with_hass")?;
 

--- a/src/service/http.rs
+++ b/src/service/http.rs
@@ -42,13 +42,13 @@ async fn resolve_device_for_control(
     id: &str,
 ) -> Result<Coordinator, Response> {
     state
-        .resolve_device_for_control(&id)
+        .resolve_device_for_control(id)
         .await
         .map_err(not_found)
 }
 
 async fn resolve_device_read_only(state: &StateHandle, id: &str) -> Result<Device, Response> {
-    state.resolve_device_read_only(&id).await.map_err(not_found)
+    state.resolve_device_read_only(id).await.map_err(not_found)
 }
 
 /// Returns a json array of device information
@@ -235,7 +235,7 @@ async fn activate_one_click(
         .ok_or_else(|| anyhow::anyhow!("AWS IoT client is not available"))
         .map_err(generic)?;
 
-    iot.activate_one_click(&item).await.map_err(generic)?;
+    iot.activate_one_click(item).await.map_err(generic)?;
 
     Ok(response_with_code(StatusCode::OK, "ok"))
 }

--- a/src/service/http.rs
+++ b/src/service/http.rs
@@ -175,6 +175,21 @@ async fn device_set_scene(
     Ok(response_with_code(StatusCode::OK, "ok"))
 }
 
+/// Returns a JSON array of the available scenes with category structure preserved
+async fn device_list_scenes_categorized(
+    State(state): State<StateHandle>,
+    Path(id): Path<String>,
+) -> Result<Response, Response> {
+    let device = resolve_device_read_only(&state, &id).await?;
+
+    let catalog = state
+        .device_list_scenes_categorized(&device)
+        .await
+        .map_err(generic)?;
+
+    Ok(Json(catalog).into_response())
+}
+
 /// Returns a JSON array of the available scene names for a given device
 async fn device_list_scenes(
     State(state): State<StateHandle>,
@@ -245,6 +260,10 @@ fn build_router(state: StateHandle) -> Router {
         .route("/api/device/{id}/color/{color}", get(device_set_color))
         .route("/api/device/{id}/scene/{scene}", get(device_set_scene))
         .route("/api/device/{id}/scenes", get(device_list_scenes))
+        .route(
+            "/api/device/{id}/scene-catalog",
+            get(device_list_scenes_categorized),
+        )
         .route("/api/oneclicks", get(list_one_clicks))
         .route("/api/oneclick/activate/{scene}", get(activate_one_click))
         .route("/", get(redirect_to_index))

--- a/src/service/iot.rs
+++ b/src/service/iot.rs
@@ -426,7 +426,7 @@ async fn run_iot_subscriber(
                                                     g: nl.g,
                                                     b: nl.b,
                                                 };
-                                                device.set_nightlight_state(nl.clone());
+                                                device.set_nightlight_state(nl);
                                             }
                                             GoveeBlePacket::NotifyHumidifierAutoMode(
                                                 HumidifierAutoMode { target_humidity },

--- a/src/service/quirks.rs
+++ b/src/service/quirks.rs
@@ -299,6 +299,7 @@ fn load_quirks() -> HashMap<String, Quirk> {
         Quirk::lan_api_capable_light("H6076", FLOOR_LAMP),
         Quirk::lan_api_capable_light("H6078", FLOOR_LAMP),
         Quirk::lan_api_capable_light("H6087", WALL_SCONCE),
+        Quirk::lan_api_capable_light("H60B0", STRIP),
         Quirk::lan_api_capable_light("H610A", STRIP),
         Quirk::lan_api_capable_light("H610B", STRIP),
         Quirk::lan_api_capable_light("H6117", STRIP),

--- a/src/service/quirks.rs
+++ b/src/service/quirks.rs
@@ -12,7 +12,7 @@ pub enum HumidityUnits {
 }
 
 impl HumidityUnits {
-    pub fn from_reading_to_relative_percent(&self, value: f64) -> f64 {
+    pub fn reading_to_relative_percent(&self, value: f64) -> f64 {
         match self {
             Self::RelativePercent => value,
             Self::RelativePercentTimes100 => value / 100.,

--- a/src/service/state.rs
+++ b/src/service/state.rs
@@ -8,12 +8,25 @@ use crate::service::iot::IotClient;
 use crate::temperature::{TemperatureScale, TemperatureValue};
 use crate::undoc_api::GoveeUndocumentedApi;
 use anyhow::Context;
+use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::{MappedMutexGuard, Mutex, MutexGuard, Semaphore};
 use tokio::time::{sleep, Duration};
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SceneCatalogCategory {
+    pub name: String,
+    pub scenes: Vec<SceneCatalogEntry>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SceneCatalogEntry {
+    pub name: String,
+    pub icon_urls: Vec<String>,
+}
 
 #[derive(Default)]
 pub struct State {
@@ -620,6 +633,87 @@ impl State {
         }
 
         log::trace!("Platform API unavailable: Don't know how to list scenes for {device}");
+
+        Ok(vec![])
+    }
+
+    /// Returns the scene catalog with category structure preserved.
+    /// Unlike `device_list_scenes()` which returns a flat `Vec<String>`,
+    /// this preserves category groupings and icon URLs from the Govee API.
+    /// Results are cached in the Device struct after first fetch.
+    pub async fn device_list_scenes_categorized(
+        &self,
+        device: &Device,
+    ) -> anyhow::Result<Vec<SceneCatalogCategory>> {
+        // Return cached catalog if available
+        if let Some(cached) = device.scene_catalog() {
+            return Ok(cached.clone());
+        }
+
+        let catalog = self.fetch_scene_catalog(device).await?;
+
+        // Cache the result for future calls
+        if !catalog.is_empty() {
+            self.device_mut(&device.sku, &device.id)
+                .await
+                .set_scene_catalog(catalog.clone());
+        }
+
+        Ok(catalog)
+    }
+
+    /// Fetches the scene catalog from the Govee API (no caching).
+    async fn fetch_scene_catalog(
+        &self,
+        device: &Device,
+    ) -> anyhow::Result<Vec<SceneCatalogCategory>> {
+        // Try platform API first (no category info — wrap in "All")
+        if let Some(client) = self.get_platform_client().await {
+            if let Some(info) = &device.http_device_info {
+                let names = sort_and_dedup_scenes(client.list_scene_names(info).await?);
+                if !names.is_empty() {
+                    return Ok(vec![SceneCatalogCategory {
+                        name: "All".to_string(),
+                        scenes: names
+                            .into_iter()
+                            .map(|name| SceneCatalogEntry {
+                                name,
+                                icon_urls: vec![],
+                            })
+                            .collect(),
+                    }]);
+                }
+            }
+        }
+
+        // Try undocumented API (has categories)
+        if let Ok(categories) = GoveeUndocumentedApi::get_scenes_for_device(&device.sku).await {
+            let mut result = vec![];
+            for cat in categories {
+                let mut scenes = vec![];
+                for scene in cat.scenes {
+                    // Same validity filter as device_list_scenes():
+                    // include only if at least one LightEffectEntry has scene_code != 0
+                    let valid = scene
+                        .light_effects
+                        .iter()
+                        .any(|effect| effect.scene_code != 0);
+                    if valid {
+                        scenes.push(SceneCatalogEntry {
+                            name: scene.scene_name,
+                            icon_urls: scene.icon_urls,
+                        });
+                    }
+                }
+                if !scenes.is_empty() {
+                    result.push(SceneCatalogCategory {
+                        name: cat.category_name,
+                        scenes,
+                    });
+                }
+            }
+            return Ok(result);
+        }
 
         Ok(vec![])
     }

--- a/src/service/state.rs
+++ b/src/service/state.rs
@@ -483,7 +483,7 @@ impl State {
         apply: F,
     ) -> anyhow::Result<bool> {
         let mut params: SetHumidifierNightlightParams =
-            device.nightlight_state.clone().unwrap_or_default().into();
+            device.nightlight_state.unwrap_or_default().into();
         (apply)(&mut params);
 
         if let Ok(command) = Base64HexBytes::encode_for_sku(&device.sku, &params) {
@@ -774,7 +774,7 @@ impl State {
     // Take care not to call this while you hold a mutable device
     // reference, as that will deadlock!
     pub async fn notify_of_state_change(self: &Arc<Self>, device_id: &str) -> anyhow::Result<()> {
-        let Some(canonical_device) = self.device_by_id(&device_id).await else {
+        let Some(canonical_device) = self.device_by_id(device_id).await else {
             anyhow::bail!("cannot find device {device_id}!?");
         };
 

--- a/src/service/state.rs
+++ b/src/service/state.rs
@@ -26,6 +26,7 @@ pub struct SceneCatalogCategory {
 pub struct SceneCatalogEntry {
     pub name: String,
     pub icon_urls: Vec<String>,
+    pub hint: String,
 }
 
 #[derive(Default)]
@@ -679,6 +680,7 @@ impl State {
                             .map(|name| SceneCatalogEntry {
                                 name,
                                 icon_urls: vec![],
+                                hint: String::new(),
                             })
                             .collect(),
                     }]);
@@ -702,6 +704,7 @@ impl State {
                         scenes.push(SceneCatalogEntry {
                             name: scene.scene_name,
                             icon_urls: scene.icon_urls,
+                            hint: scene.scenes_hint,
                         });
                     }
                 }

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -149,7 +149,7 @@ impl TemperatureValue {
 
     pub fn as_unit(&self, unit: TemperatureUnits) -> Self {
         if self.unit == unit {
-            return self.clone();
+            return *self;
         }
 
         let normalized = self.value / self.unit.factor();
@@ -196,7 +196,7 @@ fn atoi<F: FromStr>(input: &str) -> Result<(F, &str), <F as FromStr>::Err> {
     let input = input.trim();
     let i = input
         .find(|c: char| !c.is_numeric() && c != '.')
-        .unwrap_or_else(|| input.len());
+        .unwrap_or(input.len());
     let number = input[..i].parse::<F>()?;
     Ok((number, input[i..].trim()))
 }

--- a/src/undoc_api.rs
+++ b/src/undoc_api.rs
@@ -390,7 +390,7 @@ impl GoveeUndocumentedApi {
 
         for c in catalog {
             for s in c.scenes {
-                if let Some(param_id) = s.light_effects.get(0).map(|e| e.scence_param_id) {
+                if let Some(param_id) = s.light_effects.first().map(|e| e.scence_param_id) {
                     options.push(EnumOption {
                         name: s.scene_name,
                         value: json!({


### PR DESCRIPTION
## Summary

Pipes the Govee undocumented API's `scenesHint` field through `SceneCatalogEntry` to MQTT retained messages and the REST endpoint. This enables the Scene Deck v2 dashboard card to display scene description hints alongside names and icons.

**Changes:**
- Added `hint: String` field to `SceneCatalogEntry` struct
- Undoc API path: maps `scene.scenes_hint` into the new field
- Platform API path: defaults to empty string (no hint data available)

No other files need changes — the struct derives `Serialize`/`Deserialize`, so all consumers (MQTT, REST) automatically include the new field.

## Test Coverage

All 40 existing tests pass. No new tests needed — structural field addition covered by existing `undoc_api::test::get_device_scenes` and `platform_api::test::get_device_scenes` tests.

## Pre-Landing Review

No issues found.

## Plan Completion

Plan: `zesty-nibbling-stardust.md`
- [x] Add `hint` field to `SceneCatalogEntry`
- [x] Pipe `scenes_hint` in undocumented API path
- [x] Default empty hint in platform API path

3/3 items DONE.

## Test plan

- [x] `cargo build --all` passes
- [x] `cargo test --all` passes (40 tests, 0 failures)
- [x] `cargo clippy --all -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)