### PR TITLE
Fix H66A1 (Govee TV Backlight 3 Pro) issue

### DIFF
--- a/src/hass_mqtt/enumerator.rs
+++ b/src/hass_mqtt/enumerator.rs
@@ -200,12 +200,16 @@ pub async fn enumerate_entities_for_device<'a>(
                     entities.add(TargetTemperatureEntity::new(&d, state, cap).await?);
                 }
 
-                kind => {
-                    log::warn!(
-                        "Do something about {kind:?} {} for {d} {cap:?}",
-                        cap.instance
-                    );
+                DeviceCapabilityKind::Other(ref s) if s == "devices.capabilities.movie_setting" => {
+               // Ignore movieMode capability (not yet supported)
                 }
+
+               kind => {
+                   log::warn!(
+                       "Do something about {kind:?} {} for {d} {cap:?}",
+                       cap.instance
+                     );
+                 }
             }
         }
 

--- a/src/platform_api.rs
+++ b/src/platform_api.rs
@@ -958,6 +958,7 @@ pub struct IntegerRange {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct EnumOption {
+    #[serde(deserialize_with = "deserialize_name_field")]
     pub name: String,
     #[serde(default)]
     pub value: JsonValue,
@@ -1161,5 +1162,28 @@ mod test {
             serde_json::to_string(&DeviceType::Other("something".to_string())).unwrap(),
             "\"something\""
         );
+    }
+}
+
+fn deserialize_name_field<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde_json::Value;
+
+    let v = Value::deserialize(deserializer)?;
+
+    match v {
+        Value::String(s) => Ok(s),
+        Value::Object(map) => {
+            if let Some(Value::String(en)) = map.get("en") {
+                Ok(en.clone())
+            } else if let Some(Value::String(key)) = map.get("key") {
+                Ok(key.clone())
+            } else {
+                Ok(serde_json::Value::Object(map).to_string())
+            }
+        }
+        _ => Ok(v.to_string()),
     }
 }


### PR DESCRIPTION
### Problem

`govee2mqtt` crashes during device discovery with:

invalid type: map, expected a string

This occurs when the Govee cloud API returns localized enum option names.

Example:

"name": { "en": "Game", ... }

---

### Cause

`EnumOption.name` is defined as `String`, but the API may return an object.

---

### Fix

Use a custom deserializer to support both formats.

- Handles `"name": "Game"`
- Handles `"name": { "en": "Game", ... }`

---

### Additional

Suppress repeated warnings for:

devices.capabilities.movie_setting

---

### Result

- No startup crash
- H66A1 works correctly
- Cleaner logs