### PR TITLE
fix: bump hardcoded APP_VERSION to be compatible again with Govee API

### DIFF
--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -34,6 +34,7 @@ schema:
   govee_email: "str?"
   govee_password: "password?"
   govee_api_key: "password?"
+  govee_app_version: "str?"
   mqtt_host: "str?"
   mqtt_port: "int?"
   mqtt_username: "str?"

--- a/addon/run.sh
+++ b/addon/run.sh
@@ -67,6 +67,10 @@ if bashio::config.has_value govee_api_key ; then
   export GOVEE_API_KEY="$(bashio::config govee_api_key)"
 fi
 
+if bashio::config.has_value govee_app_version ; then
+  export GOVEE_APP_VERSION="$(bashio::config govee_app_version)"
+fi
+
 if bashio::config.has_value no_multicast ; then
   export GOVEE_LAN_NO_MULTICAST="$(bashio::config no_multicast)"
 fi

--- a/addon/translations/en.yaml
+++ b/addon/translations/en.yaml
@@ -23,6 +23,12 @@ configuration:
       at https://developer.govee.com/reference/apply-you-govee-api-key
       Configuring this will cause govee2mqtt to require working
       internet connectivity on startup.
+  govee_app_version:
+    name: Govee App Version Override
+    description: >-
+      Override the Govee app version string sent in API requests.
+      Only set this if you need to match a newer version of the
+      Govee Home app. If left blank, the built-in default is used.
 
   mqtt_host:
     name: MQTT Broker Host Name

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -19,6 +19,7 @@ here](https://developer.govee.com/reference/apply-you-govee-api-key).
 |`--govee-email`|`GOVEE_EMAIL`|`govee_email`|The email address you registered with your govee account|
 |`--govee-password`|`GOVEE_PASSWORD`|`govee_password`|The password you registered for your govee account|
 |`--api-key`|`GOVEE_API_KEY`|`govee_api_key`|The API key you requested from Govee support|
+|`--govee-app-version`|`GOVEE_APP_VERSION`|`govee_app_version`|Override the app version sent in Govee API headers (default: built-in)|
 
 *Concerned about sharing your credentials? See [Privacy](PRIVACY.md) for
 information about how data is used and retained by `govee2mqtt`*

--- a/src/undoc_api.rs
+++ b/src/undoc_api.rs
@@ -16,7 +16,16 @@ use uuid::Uuid;
 
 // <https://github.com/constructorfleet/homebridge-ultimate-govee/blob/main/src/data/clients/RestClient.ts>
 
-const APP_VERSION: &str = "7.4.10";
+const DEFAULT_APP_VERSION: &str = "7.4.10";
+static APP_VERSION_OVERRIDE: once_cell::sync::OnceCell<String> = once_cell::sync::OnceCell::new();
+
+fn app_version() -> &'static str {
+    APP_VERSION_OVERRIDE
+        .get()
+        .map(|s| s.as_str())
+        .unwrap_or(DEFAULT_APP_VERSION)
+}
+
 const HALF_DAY: Duration = Duration::from_secs(3600 * 12);
 const ONE_DAY: Duration = Duration::from_secs(86400);
 const ONE_WEEK: Duration = Duration::from_secs(86400 * 7);
@@ -54,7 +63,8 @@ impl<T: std::fmt::Debug> std::ops::Deref for Redacted<T> {
 
 fn user_agent() -> String {
     format!(
-        "GoveeHome/{APP_VERSION} (com.ihoment.GoVeeSensor; build:2; iOS 18.4.0) Alamofire/5.10.2"
+        "GoveeHome/{} (com.ihoment.GoVeeSensor; build:2; iOS 18.4.0) Alamofire/5.10.2",
+        app_version()
     )
 }
 
@@ -79,6 +89,13 @@ pub struct UndocApiArguments {
     /// the GOVEE_PASSWORD environment variable.
     #[arg(long, global = true)]
     pub govee_password: Option<String>,
+
+    /// Override the Govee app version sent in API headers.
+    /// If not passed here, it will be read from
+    /// the GOVEE_APP_VERSION environment variable.
+    /// Defaults to the built-in version if not set.
+    #[arg(long, global = true)]
+    pub govee_app_version: Option<String>,
 
     /// Where to store the AWS IoT key file.
     #[arg(long, global = true, default_value = "/dev/shm/govee.iot.key")]
@@ -126,7 +143,19 @@ impl UndocApiArguments {
         })
     }
 
+    pub fn resolve_app_version(&self) -> anyhow::Result<()> {
+        let version = match &self.govee_app_version {
+            Some(v) => Some(v.to_string()),
+            None => opt_env_var("GOVEE_APP_VERSION")?,
+        };
+        if let Some(v) = version {
+            let _ = APP_VERSION_OVERRIDE.set(v);
+        }
+        Ok(())
+    }
+
     pub fn api_client(&self) -> anyhow::Result<GoveeUndocumentedApi> {
+        self.resolve_app_version()?;
         let email = self.email()?;
         let password = self.password()?;
         Ok(GoveeUndocumentedApi::new(email, password))
@@ -170,7 +199,7 @@ impl GoveeUndocumentedApi {
                     .build()?
                     .request(Method::GET, "https://app2.govee.com/app/v1/account/iot/key")
                     .header("Authorization", format!("Bearer {token}"))
-                    .header("appVersion", APP_VERSION)
+                    .header("appVersion", app_version())
                     .header("clientId", &self.client_id)
                     .header("clientType", "1")
                     .header("iotVersion", "0")
@@ -207,7 +236,7 @@ impl GoveeUndocumentedApi {
                 Method::POST,
                 "https://app2.govee.com/account/rest/account/v1/login",
             )
-            .header("appVersion", APP_VERSION)
+            .header("appVersion", app_version())
             .header("clientId", &self.client_id)
             .header("clientType", "1")
             .header("iotVersion", "0")
@@ -265,7 +294,7 @@ impl GoveeUndocumentedApi {
                 "https://app2.govee.com/device/rest/devices/v1/list",
             )
             .header("Authorization", format!("Bearer {token}"))
-            .header("appVersion", APP_VERSION)
+            .header("appVersion", app_version())
             .header("clientId", &self.client_id)
             .header("clientType", "1")
             .header("iotVersion", "0")
@@ -367,7 +396,7 @@ impl GoveeUndocumentedApi {
                             "https://app2.govee.com/appsku/v1/light-effect-libraries?sku={sku}"
                         ),
                     )
-                    .header("AppVersion", APP_VERSION)
+                    .header("AppVersion", app_version())
                     .header("User-Agent", user_agent())
                     .send()
                     .await?;
@@ -434,7 +463,7 @@ impl GoveeUndocumentedApi {
                         "https://app2.govee.com/bff-app/v1/exec-plat/home",
                     )
                     .header("Authorization", format!("Bearer {community_token}"))
-                    .header("appVersion", APP_VERSION)
+                    .header("appVersion", app_version())
                     .header("clientId", &self.client_id)
                     .header("clientType", "1")
                     .header("iotVersion", "0")

--- a/src/undoc_api.rs
+++ b/src/undoc_api.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 
 // <https://github.com/constructorfleet/homebridge-ultimate-govee/blob/main/src/data/clients/RestClient.ts>
 
-const APP_VERSION: &str = "6.5.02";
+const APP_VERSION: &str = "7.4.10";
 const HALF_DAY: Duration = Duration::from_secs(3600 * 12);
 const ONE_DAY: Duration = Duration::from_secs(86400);
 const ONE_WEEK: Duration = Duration::from_secs(86400 * 7);
@@ -54,7 +54,7 @@ impl<T: std::fmt::Debug> std::ops::Deref for Redacted<T> {
 
 fn user_agent() -> String {
     format!(
-        "GoveeHome/{APP_VERSION} (com.ihoment.GoVeeSensor; build:2; iOS 16.5.0) Alamofire/5.6.4"
+        "GoveeHome/{APP_VERSION} (com.ihoment.GoVeeSensor; build:2; iOS 18.4.0) Alamofire/5.10.2"
     )
 }
 


### PR DESCRIPTION
The root cause is clear: the hardcoded APP_VERSION = "6.5.02" in undoc_api.rs is rejected by Govee's API.

The fix is straightforward: the hardcoded APP_VERSION = "6.5.02" in src/undoc_api.rs is rejected by Govee's API because it's too old. The current Govee Home app is version 7.4.10 (released today, April 3, 2026).

Line 19: APP_VERSION bumped from "6.5.02" to "7.4.10" (current Govee Home app version, released April 3, 2026)
Line 57: User-Agent string updated with iOS 18.4.0 (from 16.5.0) and Alamofire/5.10.2 (from 5.6.4)