### PR TITLE
fix: add Govee 2FA login support

### DIFF
--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -33,6 +33,7 @@ schema:
   temperature_scale: "str?"
   govee_email: "str?"
   govee_password: "password?"
+  govee_2fa_code: "password?"
   govee_api_key: "password?"
   mqtt_host: "str?"
   mqtt_port: "int?"

--- a/addon/run.sh
+++ b/addon/run.sh
@@ -63,6 +63,10 @@ if bashio::config.has_value govee_password ; then
   export GOVEE_PASSWORD="$(bashio::config govee_password)"
 fi
 
+if bashio::config.has_value govee_2fa_code ; then
+  export GOVEE_2FA_CODE="$(bashio::config govee_2fa_code)"
+fi
+
 if bashio::config.has_value govee_api_key ; then
   export GOVEE_API_KEY="$(bashio::config govee_api_key)"
 fi
@@ -87,7 +91,7 @@ if bashio::config.has_value temperature_scale ; then
   export GOVEE_TEMPERATURE_SCALE="$(bashio::config temperature_scale)"
 fi
 
-env | grep GOVEE_ | sed -r 's/_(EMAIL|KEY|PASSWORD)=.*/_\1=REDACTED/'
+env | grep GOVEE_ | sed -r 's/_(EMAIL|KEY|PASSWORD|CODE)=.*/_\1=REDACTED/'
 set -x
 
 cd /app

--- a/addon/translations/en.yaml
+++ b/addon/translations/en.yaml
@@ -15,6 +15,11 @@ configuration:
     name: Govee Account Password
     description: >-
       The password you registered with your Govee Account
+  govee_2fa_code:
+    name: Govee 2FA Code
+    description: >-
+      The verification code Govee sends to your account email when
+      additional login verification is required.
   govee_api_key:
     name: Govee API Key
     description: >-
@@ -89,7 +94,6 @@ configuration:
       global broadcast address 255.255.255.255. To be honest, if
       multicast-UDP doesn't work, this isn't likely to work any
       better.
-
 
 
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -18,6 +18,7 @@ here](https://developer.govee.com/reference/apply-you-govee-api-key).
 |---|---|-----|-------|
 |`--govee-email`|`GOVEE_EMAIL`|`govee_email`|The email address you registered with your govee account|
 |`--govee-password`|`GOVEE_PASSWORD`|`govee_password`|The password you registered for your govee account|
+|`--govee-2fa-code`|`GOVEE_2FA_CODE`|`govee_2fa_code`|The verification code Govee sends when account login requires 2FA|
 |`--api-key`|`GOVEE_API_KEY`|`govee_api_key`|The API key you requested from Govee support|
 
 *Concerned about sharing your credentials? See [Privacy](PRIVACY.md) for
@@ -65,4 +66,3 @@ You will also need to configure `govee2mqtt` to use the same broker:
 |`--mqtt-port`|`GOVEE_MQTT_PORT`|`mqtt_port`|The port number of the mqtt broker. The default is `1883`|
 |`--mqtt-username`|`GOVEE_MQTT_USER`|`mqtt_username`|If your broker requires authentication, the username to use|
 |`--mqtt-password`|`GOVEE_MQTT_PASSWORD`|`mqtt_password`|If your broker requires authentication, the password to use|
-

--- a/src/undoc_api.rs
+++ b/src/undoc_api.rs
@@ -6,6 +6,7 @@ use crate::platform_api::{
     from_json, http_response_body, DeviceCapability, DeviceCapabilityKind, DeviceParameters,
     EnumOption,
 };
+use anyhow::Context;
 use reqwest::Method;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -16,7 +17,7 @@ use uuid::Uuid;
 
 // <https://github.com/constructorfleet/homebridge-ultimate-govee/blob/main/src/data/clients/RestClient.ts>
 
-const APP_VERSION: &str = "6.5.02";
+const APP_VERSION: &str = "7.4.10";
 const HALF_DAY: Duration = Duration::from_secs(3600 * 12);
 const ONE_DAY: Duration = Duration::from_secs(86400);
 const ONE_WEEK: Duration = Duration::from_secs(86400 * 7);
@@ -54,8 +55,26 @@ impl<T: std::fmt::Debug> std::ops::Deref for Redacted<T> {
 
 fn user_agent() -> String {
     format!(
-        "GoveeHome/{APP_VERSION} (com.ihoment.GoVeeSensor; build:2; iOS 16.5.0) Alamofire/5.6.4"
+        "GoveeHome/{APP_VERSION} (com.ihoment.GoVeeSensor; build:8; iOS 26.5.0) Alamofire/5.11.0"
     )
+}
+
+fn optional_trimmed(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let value = value.trim();
+        (!value.is_empty()).then(|| value.to_string())
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct GoveeApiStatus {
+    status: u64,
+    #[serde(default)]
+    message: String,
+}
+
+fn govee_api_status(body: &[u8]) -> Option<GoveeApiStatus> {
+    serde_json::from_slice(body).ok()
 }
 
 pub fn ms_timestamp() -> String {
@@ -91,6 +110,12 @@ pub struct UndocApiArguments {
     /// Where to find the AWS root CA certificate
     #[arg(long, global = true, default_value = "AmazonRootCA1.pem")]
     pub amazon_root_ca: PathBuf,
+
+    /// Optional 2FA verification code sent by Govee.
+    /// If not passed here, it will be read from
+    /// the GOVEE_2FA_CODE environment variable.
+    #[arg(long, global = true)]
+    pub govee_2fa_code: Option<String>,
 }
 
 impl UndocApiArguments {
@@ -126,10 +151,22 @@ impl UndocApiArguments {
         })
     }
 
+    pub fn opt_2fa_code(&self) -> anyhow::Result<Option<String>> {
+        match &self.govee_2fa_code {
+            Some(code) => Ok(optional_trimmed(Some(code.to_string()))),
+            None => Ok(optional_trimmed(opt_env_var("GOVEE_2FA_CODE")?)),
+        }
+    }
+
     pub fn api_client(&self) -> anyhow::Result<GoveeUndocumentedApi> {
         let email = self.email()?;
         let password = self.password()?;
-        Ok(GoveeUndocumentedApi::new(email, password))
+        let two_fa_code = self.opt_2fa_code()?;
+        Ok(GoveeUndocumentedApi::new_with_2fa_code(
+            email,
+            password,
+            two_fa_code,
+        ))
     }
 }
 
@@ -138,10 +175,19 @@ pub struct GoveeUndocumentedApi {
     email: String,
     password: String,
     client_id: String,
+    two_fa_code: Option<String>,
 }
 
 impl GoveeUndocumentedApi {
     pub fn new<E: Into<String>, P: Into<String>>(email: E, password: P) -> Self {
+        Self::new_with_2fa_code(email, password, None)
+    }
+
+    pub fn new_with_2fa_code<E: Into<String>, P: Into<String>>(
+        email: E,
+        password: P,
+        two_fa_code: Option<String>,
+    ) -> Self {
         let email = email.into();
         let password = password.into();
         let client_id = Uuid::new_v5(&Uuid::NAMESPACE_DNS, email.as_bytes());
@@ -150,7 +196,97 @@ impl GoveeUndocumentedApi {
             email,
             password,
             client_id,
+            two_fa_code: optional_trimmed(two_fa_code),
         }
+    }
+
+    fn login_request_body(&self) -> JsonValue {
+        let mut body = json!({
+            "email": self.email,
+            "password": self.password,
+            "client": &self.client_id,
+        });
+
+        if let Some(code) = &self.two_fa_code {
+            body["code"] = json!(code);
+        }
+
+        body
+    }
+
+    async fn request_2fa_code(&self) -> anyhow::Result<()> {
+        let cache_key = format!("2fa-verification-request-{}", self.client_id);
+        let _: String = cache_get(
+            CacheGetOptions {
+                topic: "undoc-api",
+                key: &cache_key,
+                soft_ttl: FIFTEEN_MINS,
+                hard_ttl: FIFTEEN_MINS,
+                negative_ttl: Duration::from_secs(10),
+                allow_stale: false,
+            },
+            async {
+                log::info!("Requesting a Govee 2FA verification code");
+                self.request_2fa_code_impl().await?;
+                Ok(CacheComputeResult::Value(ms_timestamp()))
+            },
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn request_2fa_code_impl(&self) -> anyhow::Result<()> {
+        let response = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()?
+            .request(
+                Method::POST,
+                "https://app2.govee.com/account/rest/account/v1/verification",
+            )
+            .header("appVersion", APP_VERSION)
+            .header("clientId", &self.client_id)
+            .header("clientType", "1")
+            .header("iotVersion", "0")
+            .header("timestamp", ms_timestamp())
+            .header("User-Agent", user_agent())
+            .json(&json!({
+                "type": 8,
+                "email": self.email,
+            }))
+            .send()
+            .await?;
+
+        let url = response.url().clone();
+        let status = response.status();
+        let body_bytes = response.bytes().await.with_context(|| {
+            format!(
+                "request {url} status {}: {}, and failed to read response body",
+                status.as_u16(),
+                status.canonical_reason().unwrap_or("")
+            )
+        })?;
+
+        if !status.is_success() {
+            anyhow::bail!(
+                "request {url} status {}: {}. Response body: {}",
+                status.as_u16(),
+                status.canonical_reason().unwrap_or(""),
+                String::from_utf8_lossy(&body_bytes)
+            );
+        }
+
+        if let Some(api_status) = govee_api_status(&body_bytes) {
+            if api_status.status != 200 {
+                anyhow::bail!(
+                    "Govee 2FA verification request failed with status {}: {}",
+                    api_status.status,
+                    api_status.message
+                );
+            }
+        }
+
+        Ok(())
     }
 
     #[allow(unused)]
@@ -205,7 +341,7 @@ impl GoveeUndocumentedApi {
             .build()?
             .request(
                 Method::POST,
-                "https://app2.govee.com/account/rest/account/v1/login",
+                "https://app2.govee.com/account/rest/account/v2/login",
             )
             .header("appVersion", APP_VERSION)
             .header("clientId", &self.client_id)
@@ -213,15 +349,66 @@ impl GoveeUndocumentedApi {
             .header("iotVersion", "0")
             .header("timestamp", ms_timestamp())
             .header("User-Agent", user_agent())
-            .json(&serde_json::json!({
-                "email": self.email,
-                "password": self.password,
-                "client": &self.client_id,
-            }))
+            .json(&self.login_request_body())
             .send()
             .await?;
 
-        let resp: Response = http_response_body(response).await?;
+        let url = response.url().clone();
+        let status = response.status();
+        let body_bytes = response.bytes().await.with_context(|| {
+            format!(
+                "request {url} status {}: {}, and failed to read response body",
+                status.as_u16(),
+                status.canonical_reason().unwrap_or("")
+            )
+        })?;
+
+        if let Some(api_status) = govee_api_status(&body_bytes) {
+            match api_status.status {
+                200 => {}
+                454 if self.two_fa_code.is_some() => {
+                    anyhow::bail!(
+                        "Govee rejected the configured 2FA verification code. \
+                         Request a new code, update GOVEE_2FA_CODE or the \
+                         Home Assistant add-on govee_2fa_code option, and restart."
+                    );
+                }
+                454 => {
+                    self.request_2fa_code().await?;
+                    anyhow::bail!(
+                        "Govee account requires 2FA verification. A verification \
+                         code was requested from Govee. Set GOVEE_2FA_CODE or the \
+                         Home Assistant add-on govee_2fa_code option to the emailed \
+                         code and restart within about 15 minutes."
+                    );
+                }
+                455 => {
+                    anyhow::bail!(
+                        "Govee rejected the configured 2FA verification code as \
+                         incorrect or expired. Request a new code, update \
+                         GOVEE_2FA_CODE or the Home Assistant add-on \
+                         govee_2fa_code option, and restart."
+                    );
+                }
+                _ => {
+                    anyhow::bail!(
+                        "Govee login failed with status {}: {}. Response body: {}",
+                        api_status.status,
+                        api_status.message,
+                        String::from_utf8_lossy(&body_bytes)
+                    );
+                }
+            }
+        }
+
+        if !status.is_success() {
+            anyhow::bail!(
+                "request {url} status {}: {}. Response body: {}",
+                status.as_u16(),
+                status.canonical_reason().unwrap_or(""),
+                String::from_utf8_lossy(&body_bytes)
+            );
+        }
 
         #[derive(Deserialize, Serialize, Debug)]
         #[allow(non_snake_case, dead_code)]
@@ -230,6 +417,13 @@ impl GoveeUndocumentedApi {
             message: String,
             status: u64,
         }
+
+        let resp: Response = serde_json::from_slice(&body_bytes).with_context(|| {
+            format!(
+                "parsing {url} login response: {}",
+                String::from_utf8_lossy(&body_bytes)
+            )
+        })?;
 
         let ttl = Duration::from_secs(resp.client.token_expire_cycle as u64);
         Ok(CacheComputeResult::WithTtl(resp.client, ttl))
@@ -242,7 +436,7 @@ impl GoveeUndocumentedApi {
                 key: "account-info",
                 soft_ttl: HALF_DAY,
                 hard_ttl: HALF_DAY,
-                negative_ttl: FIFTEEN_MINS,
+                negative_ttl: Duration::from_secs(10),
                 allow_stale: false,
             },
             async { self.login_account_impl().await },
@@ -927,6 +1121,48 @@ pub fn embedded_json<'de, T: DeserializeOwned, D: serde::de::Deserializer<'de>>(
 mod test {
     use super::*;
     use crate::platform_api::from_json;
+
+    #[test]
+    fn optional_2fa_code_ignores_blank_values() {
+        assert_eq!(optional_trimmed(None), None);
+        assert_eq!(optional_trimmed(Some(" \t\n".to_string())), None);
+        assert_eq!(
+            optional_trimmed(Some(" 123456 ".to_string())),
+            Some("123456".to_string())
+        );
+    }
+
+    #[test]
+    fn login_request_body_omits_missing_2fa_code() {
+        let client = GoveeUndocumentedApi::new("user@example.com", "secret");
+        let body = client.login_request_body();
+
+        assert_eq!(body["email"], "user@example.com");
+        assert_eq!(body["password"], "secret");
+        assert!(body["client"].as_str().is_some());
+        assert!(body.get("code").is_none());
+    }
+
+    #[test]
+    fn login_request_body_includes_2fa_code() {
+        let client = GoveeUndocumentedApi::new_with_2fa_code(
+            "user@example.com",
+            "secret",
+            Some(" 123456 ".to_string()),
+        );
+        let body = client.login_request_body();
+
+        assert_eq!(body["code"], "123456");
+    }
+
+    #[test]
+    fn parses_govee_embedded_status() {
+        let status = govee_api_status(br#"{"status":454,"message":"verify"}"#).unwrap();
+
+        assert_eq!(status.status, 454);
+        assert_eq!(status.message, "verify");
+        assert!(govee_api_status(b"not json").is_none());
+    }
 
     #[test]
     fn get_device_scenes() {


### PR DESCRIPTION
## Summary

Fixes #647 by restoring undocumented Govee login when account 2FA is required.

- Upgrade the undocumented login endpoint from `/v1/login` to `/v2/login`
- Update the app version and User-Agent to match the confirmed working Govee app headers
- Add `GOVEE_2FA_CODE` / `--govee-2fa-code` and the Home Assistant add-on `govee_2fa_code` option
- Request a Govee verification code on `454` when no code is configured, with a 15-minute cache cooldown to avoid repeated email requests during restart loops
- Treat rejected or expired verification codes as actionable login errors
- Reduce the account-login negative cache TTL from 15 minutes to 10 seconds so users can retry within the code validity window

The API behavior is modeled after the confirmed fix in [homebridge-govee](https://github.com/homebridge-plugins/homebridge-govee/commit/25f9e52b32c80e4c22d561d43e5f16753f91f71f).

## Scope

- One commit, rebased onto current `upstream/main`
- Changed files are limited to `src/undoc_api.rs`, add-on config plumbing, add-on translation text, and `docs/CONFIG.md`
- Adds one optional Home Assistant add-on config field: `govee_2fa_code`
- No MQTT discovery topic changes
- No Home Assistant MQTT entity schema or availability-topic changes
- No fork branding, CI, image, changelog, or unrelated history changes

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all` passes (35 tests)
- [x] `cargo clippy --all -- -D warnings`
