### PR TITLE
fix: replace .expect() panics with graceful error handling in MQTT entities

### DIFF
--- a/src/hass_mqtt/climate.rs
+++ b/src/hass_mqtt/climate.rs
@@ -133,11 +133,13 @@ impl EntityInstance for TargetTemperatureEntity {
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
-        let device = self
-            .state
-            .device_by_id(&self.device_id)
-            .await
-            .expect("device to exist");
+        let Some(device) = self.state.device_by_id(&self.device_id).await else {
+            log::warn!(
+                "Device {} not found in state, skipping notify",
+                self.device_id
+            );
+            return Ok(());
+        };
 
         let quirk = device.resolve_quirk();
 

--- a/src/hass_mqtt/humidifier.rs
+++ b/src/hass_mqtt/humidifier.rs
@@ -170,11 +170,13 @@ impl EntityInstance for Humidifier {
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
-        let device = self
-            .state
-            .device_by_id(&self.device_id)
-            .await
-            .expect("device to exist");
+        let Some(device) = self.state.device_by_id(&self.device_id).await else {
+            log::warn!(
+                "Device {} not found in state, skipping notify",
+                self.device_id
+            );
+            return Ok(());
+        };
 
         match device.device_state() {
             Some(device_state) => {

--- a/src/hass_mqtt/light.rs
+++ b/src/hass_mqtt/light.rs
@@ -70,11 +70,13 @@ impl EntityInstance for DeviceLight {
             return Ok(());
         }
 
-        let device = self
-            .state
-            .device_by_id(&self.device_id)
-            .await
-            .expect("device to exist");
+        let Some(device) = self.state.device_by_id(&self.device_id).await else {
+            log::warn!(
+                "Device {} not found in state, skipping notify",
+                self.device_id
+            );
+            return Ok(());
+        };
 
         match device.device_state() {
             Some(device_state) => {

--- a/src/hass_mqtt/number.rs
+++ b/src/hass_mqtt/number.rs
@@ -126,11 +126,13 @@ impl EntityInstance for WorkModeNumber {
             .as_ref()
             .ok_or_else(|| anyhow!("state_topic is None!?"))?;
 
-        let device = self
-            .state
-            .device_by_id(&self.device_id)
-            .await
-            .expect("device to exist");
+        let Some(device) = self.state.device_by_id(&self.device_id).await else {
+            log::warn!(
+                "Device {} not found in state, skipping notify",
+                self.device_id
+            );
+            return Ok(());
+        };
 
         if let Some(cap) = device.get_state_capability_by_instance("workMode") {
             if let Some(work_mode) = cap.state.pointer("/value/workMode") {

--- a/src/hass_mqtt/select.rs
+++ b/src/hass_mqtt/select.rs
@@ -67,11 +67,13 @@ impl EntityInstance for WorkModeSelect {
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
-        let device = self
-            .state
-            .device_by_id(&self.device_id)
-            .await
-            .expect("device to exist");
+        let Some(device) = self.state.device_by_id(&self.device_id).await else {
+            log::warn!(
+                "Device {} not found in state, skipping notify",
+                self.device_id
+            );
+            return Ok(());
+        };
 
         if let Some(mode_value) = device.humidifier_work_mode {
             if let Ok(work_mode) = ParsedWorkMode::with_device(&device) {
@@ -146,11 +148,13 @@ impl EntityInstance for SceneModeSelect {
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
-        let device = self
-            .state
-            .device_by_id(&self.device_id)
-            .await
-            .expect("device to exist");
+        let Some(device) = self.state.device_by_id(&self.device_id).await else {
+            log::warn!(
+                "Device {} not found in state, skipping notify",
+                self.device_id
+            );
+            return Ok(());
+        };
 
         if let Some(device_state) = device.device_state() {
             client

--- a/src/hass_mqtt/sensor.rs
+++ b/src/hass_mqtt/sensor.rs
@@ -168,11 +168,13 @@ impl EntityInstance for CapabilitySensor {
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
-        let device = self
-            .state
-            .device_by_id(&self.device_id)
-            .await
-            .expect("device to exist");
+        let Some(device) = self.state.device_by_id(&self.device_id).await else {
+            log::warn!(
+                "Device {} not found in state, skipping notify",
+                self.device_id
+            );
+            return Ok(());
+        };
 
         let quirk = device.resolve_quirk();
 
@@ -265,11 +267,13 @@ impl EntityInstance for DeviceStatusDiagnostic {
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
-        let device = self
-            .state
-            .device_by_id(&self.device_id)
-            .await
-            .expect("device to exist");
+        let Some(device) = self.state.device_by_id(&self.device_id).await else {
+            log::warn!(
+                "Device {} not found in state, skipping notify",
+                self.device_id
+            );
+            return Ok(());
+        };
 
         let iot_state = device.compute_iot_device_state();
         let lan_state = device.compute_lan_device_state();

--- a/src/hass_mqtt/switch.rs
+++ b/src/hass_mqtt/switch.rs
@@ -88,11 +88,13 @@ impl EntityInstance for CapabilitySwitch {
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
-        let device = self
-            .state
-            .device_by_id(&self.device_id)
-            .await
-            .expect("device to exist");
+        let Some(device) = self.state.device_by_id(&self.device_id).await else {
+            log::warn!(
+                "Device {} not found in state, skipping notify",
+                self.device_id
+            );
+            return Ok(());
+        };
 
         if self.instance_name == "powerSwitch" {
             if let Some(state) = device.device_state() {

--- a/src/service/hass.rs
+++ b/src/service/hass.rs
@@ -687,8 +687,10 @@ pub async fn spawn_hass_integration(
             tokio::time::sleep(tokio::time::Duration::from_secs(30)).await;
             std::process::exit(1);
         } else {
-            log::info!("run_mqtt_loop exited. We should do something to shutdown gracefully here");
-            std::process::exit(0);
+            log::error!(
+                "run_mqtt_loop exited unexpectedly. Terminating so HA can restart the addon."
+            );
+            std::process::exit(1);
         }
     });
 


### PR DESCRIPTION
## Problem

Every `notify_state()` implementation in the MQTT entity modules calls `.expect("device to exist")` to unwrap the device lookup. If a device is temporarily missing from state (during re-enumeration, startup race, or after a device is removed from the Govee account), this panics and crashes the entire service.

Separately, `spawn_hass_integration` calls `exit(0)` when `run_mqtt_loop` exits unexpectedly. Because the exit code is 0, Home Assistant's supervisor treats this as a clean shutdown and does **not** restart the addon. The service silently dies.

## Fix

**Panic → graceful skip:** Replace all 9 `.expect("device to exist")` calls with `let-else` patterns that log a warning and return `Ok(())`. The device will be picked up on the next state notification cycle.

```rust
// Before
let device = self.state.device_by_id(&self.device_id).await.expect("device to exist");

// After
let Some(device) = self.state.device_by_id(&self.device_id).await else {
    log::warn!("Device {} not found in state, skipping notify", self.device_id);
    return Ok(());
};
```

**Exit code:** Change `exit(0)` → `exit(1)` and `log::info` → `log::error` so HA restarts the addon on unexpected MQTT loop exit.

## Scope

8 files, +67/-47 lines. Pure error handling improvement, no behavioral changes to happy-path logic.

| File | Change |
|------|--------|
| `src/hass_mqtt/climate.rs` | `.expect()` → `let-else` |
| `src/hass_mqtt/humidifier.rs` | `.expect()` → `let-else` |
| `src/hass_mqtt/light.rs` | `.expect()` → `let-else` |
| `src/hass_mqtt/number.rs` | `.expect()` → `let-else` |
| `src/hass_mqtt/select.rs` | `.expect()` → `let-else` (2 sites) |
| `src/hass_mqtt/sensor.rs` | `.expect()` → `let-else` (2 sites) |
| `src/hass_mqtt/switch.rs` | `.expect()` → `let-else` |
| `src/service/hass.rs` | `exit(0)` → `exit(1)`, `log::info` → `log::error` |

## Testing

- `cargo build --all` ✅
- `cargo test --all` — 31 passed ✅
- `cargo clippy --all` — no new warnings ✅