### PR TITLE
chore: fix all clippy warnings, pass clippy -- -D warnings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ fn main() {
             ci_tag = s.trim().to_string();
         }
     } else if let Ok(output) = std::process::Command::new("git")
-        .args(&[
+        .args([
             "-c",
             "core.abbrev=8",
             "show",

--- a/src/ble.rs
+++ b/src/ble.rs
@@ -17,6 +17,7 @@ impl std::fmt::Debug for HexBytes {
     }
 }
 
+#[allow(clippy::type_complexity)]
 pub struct PacketCodec {
     encode: Box<dyn Fn(&dyn Any) -> anyhow::Result<Vec<u8>> + Sync + Send>,
     decode: Box<dyn Fn(&[u8]) -> anyhow::Result<GoveeBlePacket> + Sync + Send>,
@@ -57,10 +58,10 @@ impl PacketManager {
                 let mut map = HashMap::new();
 
                 for codec in &self.all_codecs {
-                    if codec.supported_skus.iter().any(|s| *s == sku) {
-                        if map.insert(codec.type_id.clone(), codec.clone()).is_some() {
-                            eprintln!("Conflicting PacketCodecs for {sku} {:?}", codec.type_id);
-                        }
+                    if codec.supported_skus.contains(&sku)
+                        && map.insert(codec.type_id, codec.clone()).is_some()
+                    {
+                        eprintln!("Conflicting PacketCodecs for {sku} {:?}", codec.type_id);
                     }
                 }
 
@@ -252,7 +253,7 @@ pub trait DecodePacketParam {
 
 impl DecodePacketParam for u8 {
     fn decode_param<'a>(&mut self, data: &'a [u8]) -> anyhow::Result<&'a [u8]> {
-        *self = *data.get(0).ok_or_else(|| anyhow!("EOF"))?;
+        *self = *data.first().ok_or_else(|| anyhow!("EOF"))?;
         Ok(&data[1..])
     }
 
@@ -263,7 +264,7 @@ impl DecodePacketParam for u8 {
 
 impl DecodePacketParam for u16 {
     fn decode_param<'a>(&mut self, data: &'a [u8]) -> anyhow::Result<&'a [u8]> {
-        let lo = *data.get(0).ok_or_else(|| anyhow!("EOF"))?;
+        let lo = *data.first().ok_or_else(|| anyhow!("EOF"))?;
         let hi = *data.get(1).ok_or_else(|| anyhow!("EOF"))?;
         *self = ((hi as u16) << 8) | lo as u16;
         Ok(&data[2..])
@@ -286,14 +287,14 @@ pub struct SetHumidifierNightlightParams {
     pub brightness: u8,
 }
 
-impl Into<SetHumidifierNightlightParams> for NotifyHumidifierNightlightParams {
-    fn into(self) -> SetHumidifierNightlightParams {
+impl From<NotifyHumidifierNightlightParams> for SetHumidifierNightlightParams {
+    fn from(val: NotifyHumidifierNightlightParams) -> Self {
         SetHumidifierNightlightParams {
-            on: self.on,
-            r: self.r,
-            g: self.g,
-            b: self.b,
-            brightness: self.brightness,
+            on: val.on,
+            r: val.r,
+            g: val.g,
+            b: val.b,
+            brightness: val.brightness,
         }
     }
 }
@@ -312,9 +313,9 @@ pub struct NotifyHumidifierNightlightParams {
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TargetHumidity(u8);
 
-impl Into<u8> for TargetHumidity {
-    fn into(self) -> u8 {
-        self.0
+impl From<TargetHumidity> for u8 {
+    fn from(val: TargetHumidity) -> Self {
+        val.0
     }
 }
 
@@ -381,7 +382,7 @@ impl SetSceneCode {
         let mut last_line_marker = 1;
 
         for b in bytes {
-            if data.len() % 19 == 0 {
+            if data.len().is_multiple_of(19) {
                 num_lines += 1;
 
                 data.push(0xa3);
@@ -478,7 +479,7 @@ impl<'de> Deserialize<'de> for Base64HexBytes {
 fn calculate_checksum(data: &[u8]) -> u8 {
     let mut checksum: u8 = 0;
     for &b in data {
-        checksum = checksum ^ b;
+        checksum ^= b;
     }
     checksum
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -17,7 +17,7 @@ fn cache_file_name() -> PathBuf {
     let cache_dir = std::env::var("GOVEE_CACHE_DIR")
         .ok()
         .map(PathBuf::from)
-        .or_else(|| dirs_next::cache_dir())
+        .or_else(dirs_next::cache_dir)
         .expect("failed to resolve cache dir");
 
     cache_dir.join("govee2mqtt-cache.sqlite")
@@ -26,7 +26,7 @@ fn cache_file_name() -> PathBuf {
 fn open_cache() -> anyhow::Result<Arc<Cache>> {
     let cache_file = cache_file_name();
     let conn = sqlite_cache::rusqlite::Connection::open(&cache_file)
-        .expect(&format!("failed to open {cache_file:?}"));
+        .unwrap_or_else(|_| panic!("failed to open {cache_file:?}"));
     Ok(Arc::new(Cache::new(
         // We have low cardinality and can be pretty relaxed
         CacheConfig {
@@ -42,7 +42,7 @@ pub fn purge_cache() -> anyhow::Result<()> {
     let cache_file = cache_file_name();
     std::fs::remove_file(&cache_file)
         .with_context(|| format!("removing cache file {cache_file:?}"))?;
-    CACHE.store(open_cache()?.into());
+    CACHE.store(open_cache()?);
     Ok(())
 }
 

--- a/src/commands/http_control.rs
+++ b/src/commands/http_control.rs
@@ -94,7 +94,7 @@ impl HttpControlCommand {
                     .ok_or_else(|| anyhow::anyhow!("device has no colorRgb"))?;
                 let [r, g, b, _a] = color.to_rgba8();
                 let value = ((r as u32) << 16) | ((g as u32) << 8) | (b as u32);
-                let result = client.control_device(&device, &cap, value).await?;
+                let result = client.control_device(&device, cap, value).await?;
                 println!("{result:#?}");
             }
 
@@ -188,7 +188,7 @@ impl HttpControlCommand {
                             ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
                         }),
                     });
-                    let result = client.control_device(&device, &cap, value).await?;
+                    let result = client.control_device(&device, cap, value).await?;
                     println!("{result:#?}");
                 }
             }

--- a/src/commands/lan_disco.rs
+++ b/src/commands/lan_disco.rs
@@ -18,7 +18,7 @@ impl LanDiscoCommand {
         let state = crate::service::state::State::new();
 
         while let Ok(Some(lan_device)) = tokio::time::timeout_at(deadline, scan.recv()).await {
-            if !state.device_by_id(&lan_device.device).await.is_some() {
+            if state.device_by_id(&lan_device.device).await.is_none() {
                 let mut device = state.device_mut(&lan_device.sku, &lan_device.device).await;
 
                 device.set_lan_device(lan_device.clone());

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -89,7 +89,7 @@ impl ListCommand {
                 room = d
                     .room_name()
                     .map(|room| format!("({room})"))
-                    .unwrap_or_else(|| String::new()),
+                    .unwrap_or_else(String::new),
             );
         }
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::time::{sleep, Duration};
 
-pub const POLL_INTERVAL: Lazy<chrono::Duration> = Lazy::new(|| chrono::Duration::seconds(900));
+pub static POLL_INTERVAL: Lazy<chrono::Duration> = Lazy::new(|| chrono::Duration::seconds(900));
 
 #[derive(clap::Parser, Debug)]
 pub struct ServeCommand {
@@ -84,13 +84,11 @@ async fn poll_single_device(state: &StateHandle, device: &Device) -> anyhow::Res
         return Ok(());
     }
 
-    if !needs_platform {
-        if state.poll_iot_api(&device).await? {
-            return Ok(());
-        }
+    if !needs_platform && state.poll_iot_api(device).await? {
+        return Ok(());
     }
 
-    state.poll_platform_api(&device).await?;
+    state.poll_platform_api(device).await?;
 
     Ok(())
 }

--- a/src/commands/undoc.rs
+++ b/src/commands/undoc.rs
@@ -8,6 +8,7 @@ pub struct UndocCommand {
 }
 
 #[derive(clap::Parser, Debug)]
+#[allow(clippy::enum_variant_names)]
 enum SubCommand {
     DumpOneClick {},
     ShowOneClick {},
@@ -41,7 +42,7 @@ impl UndocCommand {
                 start_iot_client(&args.undoc_args, state.clone(), None).await?;
                 let iot = state.get_iot_client().await.expect("just started iot");
 
-                iot.activate_one_click(&item).await?;
+                iot.activate_one_click(item).await?;
             }
         }
         Ok(())

--- a/src/hass_mqtt/climate.rs
+++ b/src/hass_mqtt/climate.rs
@@ -129,7 +129,7 @@ impl TargetTemperatureEntity {
 #[async_trait::async_trait]
 impl EntityInstance for TargetTemperatureEntity {
     async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
-        self.number.publish(&state, &client).await
+        self.number.publish(state, client).await
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
@@ -175,7 +175,7 @@ impl EntityInstance for TargetTemperatureEntity {
 
             log::debug!("setting value to {value}");
 
-            return self.number.notify_state(&client, &value).await;
+            return self.number.notify_state(client, &value).await;
         }
 
         Ok(())

--- a/src/hass_mqtt/enumerator.rs
+++ b/src/hass_mqtt/enumerator.rs
@@ -79,7 +79,7 @@ async fn enumerate_scenes(state: &StateHandle, entities: &mut EntityList) -> any
     Ok(())
 }
 
-async fn entities_for_work_mode<'a>(
+async fn entities_for_work_mode(
     d: &ServiceDevice,
     state: &StateHandle,
     cap: &DeviceCapability,
@@ -144,8 +144,8 @@ async fn entities_for_work_mode<'a>(
     Ok(())
 }
 
-pub async fn enumerate_entities_for_device<'a>(
-    d: &'a ServiceDevice,
+pub async fn enumerate_entities_for_device(
+    d: &ServiceDevice,
     state: &StateHandle,
     entities: &mut EntityList,
 ) -> anyhow::Result<()> {
@@ -157,14 +157,14 @@ pub async fn enumerate_entities_for_device<'a>(
     entities.add(ButtonConfig::request_platform_data_for_device(d));
 
     if d.supports_rgb() || d.get_color_temperature_range().is_some() || d.supports_brightness() {
-        entities.add(DeviceLight::for_device(&d, state, None).await?);
+        entities.add(DeviceLight::for_device(d, state, None).await?);
     }
 
     if matches!(
         d.device_type(),
         DeviceType::Humidifier | DeviceType::Dehumidifier
     ) {
-        entities.add(Humidifier::new(&d, state).await?);
+        entities.add(Humidifier::new(d, state).await?);
     }
 
     if d.device_type() != DeviceType::Light {
@@ -177,7 +177,7 @@ pub async fn enumerate_entities_for_device<'a>(
         for cap in &info.capabilities {
             match &cap.kind {
                 DeviceCapabilityKind::Toggle | DeviceCapabilityKind::OnOff => {
-                    entities.add(CapabilitySwitch::new(&d, state, cap).await?);
+                    entities.add(CapabilitySwitch::new(d, state, cap).await?);
                 }
                 DeviceCapabilityKind::ColorSetting
                 | DeviceCapabilityKind::SegmentColorSetting
@@ -193,11 +193,11 @@ pub async fn enumerate_entities_for_device<'a>(
                 }
 
                 DeviceCapabilityKind::Property => {
-                    entities.add(CapabilitySensor::new(&d, state, cap).await?);
+                    entities.add(CapabilitySensor::new(d, state, cap).await?);
                 }
 
                 DeviceCapabilityKind::TemperatureSetting => {
-                    entities.add(TargetTemperatureEntity::new(&d, state, cap).await?);
+                    entities.add(TargetTemperatureEntity::new(d, state, cap).await?);
                 }
 
                 kind => {
@@ -211,7 +211,7 @@ pub async fn enumerate_entities_for_device<'a>(
 
         if let Some(segments) = info.supports_segmented_rgb() {
             for n in segments {
-                entities.add(DeviceLight::for_device(&d, state, Some(n)).await?);
+                entities.add(DeviceLight::for_device(d, state, Some(n)).await?);
             }
         }
     }

--- a/src/hass_mqtt/humidifier.rs
+++ b/src/hass_mqtt/humidifier.rs
@@ -103,17 +103,15 @@ impl Humidifier {
 
         if let Some(info) = &device.http_device_info {
             if let Some(cap) = info.capability_by_instance("humidity") {
-                match &cap.parameters {
-                    Some(DeviceParameters::Integer {
-                        range: IntegerRange { min, max, .. },
-                        unit,
-                    }) => {
-                        if unit.as_deref() == Some("unit.percent") {
-                            min_humidity.replace(*min as u8);
-                            max_humidity.replace(*max as u8);
-                        }
+                if let Some(DeviceParameters::Integer {
+                    range: IntegerRange { min, max, .. },
+                    unit,
+                }) = &cap.parameters
+                {
+                    if unit.as_deref() == Some("unit.percent") {
+                        min_humidity.replace(*min as u8);
+                        max_humidity.replace(*max as u8);
                     }
-                    _ => {}
                 }
             }
         }

--- a/src/hass_mqtt/light.rs
+++ b/src/hass_mqtt/light.rs
@@ -62,7 +62,7 @@ pub struct DeviceLight {
 #[async_trait]
 impl EntityInstance for DeviceLight {
     async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
-        self.light.publish(&state, &client).await
+        self.light.publish(state, client).await
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
@@ -155,7 +155,7 @@ impl DeviceLight {
         let unique_id = format!(
             "gv2mqtt-{id}{seg}",
             id = topic_safe_id(device),
-            seg = segment.map(|n| format!("-{n}")).unwrap_or(String::new())
+            seg = segment.map(|n| format!("-{n}")).unwrap_or_default()
         );
 
         let effect_list = if segment.is_some() {

--- a/src/hass_mqtt/number.rs
+++ b/src/hass_mqtt/number.rs
@@ -116,7 +116,7 @@ impl WorkModeNumber {
 #[async_trait]
 impl EntityInstance for WorkModeNumber {
     async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
-        self.number.publish(&state, &client).await
+        self.number.publish(state, client).await
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {

--- a/src/hass_mqtt/scene.rs
+++ b/src/hass_mqtt/scene.rs
@@ -23,7 +23,7 @@ impl SceneConfig {
 #[async_trait]
 impl EntityInstance for SceneConfig {
     async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
-        self.publish(&state, &client).await
+        self.publish(state, client).await
     }
 
     async fn notify_state(&self, _client: &HassClient) -> anyhow::Result<()> {

--- a/src/hass_mqtt/select.rs
+++ b/src/hass_mqtt/select.rs
@@ -63,7 +63,7 @@ impl WorkModeSelect {
 #[async_trait::async_trait]
 impl EntityInstance for WorkModeSelect {
     async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
-        self.select.publish(&state, &client).await
+        self.select.publish(state, client).await
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
@@ -142,7 +142,7 @@ impl SceneModeSelect {
 #[async_trait::async_trait]
 impl EntityInstance for SceneModeSelect {
     async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
-        self.select.publish(&state, &client).await
+        self.select.publish(state, client).await
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {

--- a/src/hass_mqtt/sensor.rs
+++ b/src/hass_mqtt/sensor.rs
@@ -57,11 +57,11 @@ pub struct GlobalFixedDiagnostic {
 #[async_trait]
 impl EntityInstance for GlobalFixedDiagnostic {
     async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
-        self.sensor.publish(&state, &client).await
+        self.sensor.publish(state, client).await
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
-        self.sensor.notify_state(&client, &self.value).await
+        self.sensor.notify_state(client, &self.value).await
     }
 }
 
@@ -150,7 +150,7 @@ impl CapabilitySensor {
                     icon: None,
                 },
                 state_topic: format!("gv2mqtt/sensor/{unique_id}/state"),
-                state_class: state_class,
+                state_class,
                 unit_of_measurement,
                 json_attributes_topic: None,
             },
@@ -164,7 +164,7 @@ impl CapabilitySensor {
 #[async_trait]
 impl EntityInstance for CapabilitySensor {
     async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
-        self.sensor.publish(&state, &client).await
+        self.sensor.publish(state, client).await
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
@@ -215,7 +215,7 @@ impl EntityInstance for CapabilitySensor {
                 _ => cap.state.to_string(),
             };
 
-            return self.sensor.notify_state(&client, &value).await;
+            return self.sensor.notify_state(client, &value).await;
         }
         log::trace!(
             "CapabilitySensor::notify_state: didn't find state for {device} {instance}",
@@ -261,7 +261,7 @@ impl DeviceStatusDiagnostic {
 #[async_trait]
 impl EntityInstance for DeviceStatusDiagnostic {
     async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
-        self.sensor.publish(&state, &client).await
+        self.sensor.publish(state, client).await
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {
@@ -302,7 +302,7 @@ impl EntityInstance for DeviceStatusDiagnostic {
             "overall": device_state,
         });
 
-        self.sensor.notify_state(&client, &summary).await?;
+        self.sensor.notify_state(client, &summary).await?;
         if let Some(topic) = &self.sensor.json_attributes_topic {
             client.publish_obj(topic, attributes).await?;
         }

--- a/src/hass_mqtt/switch.rs
+++ b/src/hass_mqtt/switch.rs
@@ -84,7 +84,7 @@ impl CapabilitySwitch {
 #[async_trait]
 impl EntityInstance for CapabilitySwitch {
     async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
-        self.switch.publish(&state, &client).await
+        self.switch.publish(state, client).await
     }
 
     async fn notify_state(&self, client: &HassClient) -> anyhow::Result<()> {

--- a/src/hass_mqtt/work_mode.rs
+++ b/src/hass_mqtt/work_mode.rs
@@ -32,26 +32,20 @@ impl ParsedWorkMode {
             .struct_field_by_name("workMode")
             .ok_or_else(|| anyhow!("workMode not found in {cap:?}"))?;
 
-        match &wm.field_type {
-            DeviceParameters::Enum { options } => {
-                for opt in options {
-                    work_modes.add(opt.name.to_string(), opt.value.clone());
-                }
+        if let DeviceParameters::Enum { options } = &wm.field_type {
+            for opt in options {
+                work_modes.add(opt.name.to_string(), opt.value.clone());
             }
-            _ => {}
         }
 
         if let Some(mv) = cap.struct_field_by_name("modeValue") {
-            match &mv.field_type {
-                DeviceParameters::Enum { options } => {
-                    for opt in options {
-                        let mode_name = &opt.name;
-                        if let Some(work_mode) = work_modes.get_mut(mode_name) {
-                            work_mode.add_values(opt);
-                        }
+            if let DeviceParameters::Enum { options } = &mv.field_type {
+                for opt in options {
+                    let mode_name = &opt.name;
+                    if let Some(work_mode) = work_modes.get_mut(mode_name) {
+                        work_mode.add_values(opt);
                     }
                 }
-                _ => {}
             }
         }
         Ok(work_modes)
@@ -75,19 +69,14 @@ impl ParsedWorkMode {
     pub fn adjust_for_device(&mut self, sku: &str) {
         match sku {
             "H7160" | "H7143" => {
-                self.modes
-                    .get_mut("Manual")
-                    .map(|m| m.label = "Manual: Mist Level".to_string());
+                if let Some(m) = self.modes.get_mut("Manual") {
+                    m.label = "Manual: Mist Level".to_string();
+                }
             }
-            "H7131" => {
-                self.modes.get_mut("gearMode").map(|m| {
+            "H7131" | "H7173" => {
+                if let Some(m) = self.modes.get_mut("gearMode") {
                     m.label = "Heat".to_string();
-                });
-            }
-            "H7173" => {
-                self.modes.get_mut("gearMode").map(|m| {
-                    m.label = "Heat".to_string();
-                });
+                }
             }
             _ => {
                 for mode in self.modes.values_mut() {
@@ -98,12 +87,10 @@ impl ParsedWorkMode {
     }
 
     pub fn mode_for_value(&self, value: &JsonValue) -> Option<&WorkMode> {
-        for mode in self.modes.values() {
-            if mode.value == *value {
-                return Some(mode);
-            }
-        }
-        None
+        self.modes
+            .values()
+            .find(|&mode| mode.value == *value)
+            .map(|v| v as _)
     }
 
     pub fn mode_by_name(&self, name: &str) -> Option<&WorkMode> {
@@ -112,12 +99,10 @@ impl ParsedWorkMode {
 
     #[allow(unused)]
     pub fn mode_by_label(&self, name: &str) -> Option<&WorkMode> {
-        for mode in self.modes.values() {
-            if mode.label() == name {
-                return Some(mode);
-            }
-        }
-        None
+        self.modes
+            .values()
+            .find(|&mode| mode.label() == name)
+            .map(|v| v as _)
     }
 
     pub fn get_mode_names(&self) -> Vec<String> {
@@ -143,13 +128,7 @@ impl ParsedWorkMode {
 
     #[allow(unused)]
     pub fn modes_with_values(&self) -> impl Iterator<Item = &WorkMode> {
-        self.modes.values().filter_map(|mode| {
-            if mode.values.is_empty() {
-                None
-            } else {
-                Some(mode)
-            }
-        })
+        self.modes.values().filter(|mode| !mode.values.is_empty())
     }
 }
 
@@ -237,7 +216,7 @@ impl WorkMode {
         self.default_value
             .as_ref()
             .and_then(|v| v.as_i64())
-            .or_else(|| self.values.get(0).and_then(|wmv| wmv.value.as_i64()))
+            .or_else(|| self.values.first().and_then(|wmv| wmv.value.as_i64()))
             .or_else(|| self.value_range.as_ref().map(|r| r.start))
             .unwrap_or(0)
     }
@@ -267,7 +246,7 @@ impl WorkMode {
             if item != expect {
                 return None;
             }
-            expect = expect + 1;
+            expect += 1;
         }
 
         Some(min..max + 1)

--- a/src/platform_api.rs
+++ b/src/platform_api.rs
@@ -229,8 +229,8 @@ impl GoveeApiClient {
     ) -> anyhow::Result<Vec<DeviceCapability>> {
         let mut result = vec![];
 
-        let scene_caps = self.get_device_scenes(&device).await?;
-        let diy_caps = self.get_device_diy_scenes(&device).await?;
+        let scene_caps = self.get_device_scenes(device).await?;
+        let diy_caps = self.get_device_diy_scenes(device).await?;
         let undoc_caps =
             match GoveeUndocumentedApi::synthesize_platform_api_scene_list(&device.sku).await {
                 Ok(caps) => caps,
@@ -303,13 +303,10 @@ impl GoveeApiClient {
             if let Some(DeviceParameters::Struct { fields }) = &cap.parameters {
                 for f in fields {
                     if f.field_name == "musicMode" {
-                        match &f.field_type {
-                            DeviceParameters::Enum { options } => {
-                                for opt in options {
-                                    result.push(format!("Music: {}", opt.name));
-                                }
+                        if let DeviceParameters::Enum { options } = &f.field_type {
+                            for opt in options {
+                                result.push(format!("Music: {}", opt.name));
                             }
-                            _ => {}
                         }
                     }
                 }
@@ -328,7 +325,7 @@ impl GoveeApiClient {
         device: &HttpDeviceInfo,
         scene: &str,
     ) -> anyhow::Result<ControlDeviceResponseCapability> {
-        if scene == "" {
+        if scene.is_empty() {
             // Can't set no scene
             anyhow::bail!("Cannot set scene to no-scene");
         }
@@ -342,7 +339,7 @@ impl GoveeApiClient {
                             "sensitivity": 100,
                             "autoColor": 1,
                         });
-                        return self.control_device(&device, &cap, value).await;
+                        return self.control_device(device, cap, value).await;
                     }
                 }
             }
@@ -354,7 +351,7 @@ impl GoveeApiClient {
                 Some(DeviceParameters::Enum { options }) => {
                     for opt in options {
                         if scene.eq_ignore_ascii_case(&opt.name) {
-                            return self.control_device(&device, &cap, opt.value.clone()).await;
+                            return self.control_device(device, &cap, opt.value.clone()).await;
                         }
                     }
                 }
@@ -392,7 +389,7 @@ impl GoveeApiClient {
             "unit": "Celsius",
         });
 
-        self.control_device(&device, &cap, value).await
+        self.control_device(device, cap, value).await
     }
 
     pub async fn set_work_mode(
@@ -410,7 +407,7 @@ impl GoveeApiClient {
             "modeValue": value
         });
 
-        self.control_device(&device, &cap, value).await
+        self.control_device(device, cap, value).await
     }
 
     pub async fn set_toggle_state(
@@ -427,7 +424,7 @@ impl GoveeApiClient {
             .enum_parameter_by_name(if on { "on" } else { "off" })
             .ok_or_else(|| anyhow::anyhow!("{instance} has no on/off!?"))?;
 
-        self.control_device(&device, &cap, value).await
+        self.control_device(device, cap, value).await
     }
 
     pub async fn set_power_state(
@@ -453,7 +450,7 @@ impl GoveeApiClient {
             }) => (percent as u32).max(*min).min(*max),
             _ => anyhow::bail!("unexpected parameter type for brightness"),
         };
-        self.control_device(&device, &cap, value).await
+        self.control_device(device, cap, value).await
     }
 
     pub async fn set_color_temperature(
@@ -471,7 +468,7 @@ impl GoveeApiClient {
             }) => (kelvin).max(*min).min(*max),
             _ => anyhow::bail!("unexpected parameter type for colorTemperatureK"),
         };
-        self.control_device(&device, &cap, value).await
+        self.control_device(device, cap, value).await
     }
 
     pub async fn set_color_rgb(
@@ -485,7 +482,7 @@ impl GoveeApiClient {
             .capability_by_instance("colorRgb")
             .ok_or_else(|| anyhow::anyhow!("device has no colorRgb"))?;
         let value = ((r as u32) << 16) | ((g as u32) << 8) | (b as u32);
-        self.control_device(&device, &cap, value).await
+        self.control_device(device, cap, value).await
     }
 
     pub async fn set_segment_rgb(
@@ -501,8 +498,8 @@ impl GoveeApiClient {
             .ok_or_else(|| anyhow::anyhow!("device has no segmentedColorRgb"))?;
         let value = ((r as u32) << 16) | ((g as u32) << 8) | (b as u32);
         self.control_device(
-            &device,
-            &cap,
+            device,
+            cap,
             json!({
                 "segment": vec![segment],
                 "rgb": value,
@@ -528,8 +525,8 @@ impl GoveeApiClient {
         let value = (percent as u32).max(min).min(max);
 
         self.control_device(
-            &device,
-            &cap,
+            device,
+            cap,
             json!({
                 "segment": vec![segment],
                 "brightness": value,

--- a/src/service/device.rs
+++ b/src/service/device.rs
@@ -302,7 +302,6 @@ impl Device {
         for cap in &state.capabilities {
             if let Ok(value) = serde_json::from_value::<IntegerValueState>(cap.state.clone()) {
                 if light_instance
-                    .as_deref()
                     .map(|inst| inst == cap.instance.as_str())
                     .unwrap_or(false)
                 {
@@ -439,11 +438,10 @@ impl Device {
             return false;
         }
         let device_type = self.device_type();
-        match (device_type, self.sku.as_str()) {
-            (_, "H7160") => true,
-            (DeviceType::Light, _) => true,
-            _ => false,
-        }
+        matches!(
+            (device_type, self.sku.as_str()),
+            (_, "H7160") | (DeviceType::Light, _)
+        )
     }
 
     pub fn avoid_platform_api(&self) -> bool {
@@ -587,19 +585,13 @@ impl Device {
             return Some(false);
         }
 
-        if let Some(info) = &self.undoc_device_info {
-            Some(info.entry.device_ext.device_settings.wifi_name.is_none())
-        } else {
-            // Don't know for sure
-            None
-        }
+        self.undoc_device_info
+            .as_ref()
+            .map(|info| info.entry.device_ext.device_settings.wifi_name.is_none())
     }
 
     pub fn is_controllable(&self) -> bool {
-        match self.is_ble_only_device() {
-            Some(true) => false,
-            _ => true,
-        }
+        !matches!(self.is_ble_only_device(), Some(true))
     }
 }
 

--- a/src/service/hass.rs
+++ b/src/service/hass.rs
@@ -371,7 +371,7 @@ async fn mqtt_light_segment_command(
 
         if let Some(brightness) = command.brightness {
             client
-                .set_segment_brightness(&info, segment, brightness)
+                .set_segment_brightness(info, segment, brightness)
                 .await?;
         } else if command.state == "OFF" {
             // Do nothing here. We used to set brightness to zero,
@@ -385,7 +385,7 @@ async fn mqtt_light_segment_command(
         }
         if let Some(color) = &command.color {
             client
-                .set_segment_rgb(&info, segment, color.r, color.g, color.b)
+                .set_segment_rgb(info, segment, color.r, color.g, color.b)
                 .await?;
         }
     } else {
@@ -428,7 +428,7 @@ async fn mqtt_oneclick(
         .await
         .ok_or_else(|| anyhow::anyhow!("AWS IoT client is not available"))?;
 
-    iot.activate_one_click(&item).await
+    iot.activate_one_click(item).await
 }
 
 #[derive(Deserialize)]
@@ -574,7 +574,7 @@ async fn run_mqtt_loop(
             .get_hass_client()
             .await
             .expect("have hass client")
-            .register_with_hass(&state)
+            .register_with_hass(state)
             .await
             .context("register_with_hass")?;
 

--- a/src/service/http.rs
+++ b/src/service/http.rs
@@ -42,13 +42,13 @@ async fn resolve_device_for_control(
     id: &str,
 ) -> Result<Coordinator, Response> {
     state
-        .resolve_device_for_control(&id)
+        .resolve_device_for_control(id)
         .await
         .map_err(not_found)
 }
 
 async fn resolve_device_read_only(state: &StateHandle, id: &str) -> Result<Device, Response> {
-    state.resolve_device_read_only(&id).await.map_err(not_found)
+    state.resolve_device_read_only(id).await.map_err(not_found)
 }
 
 /// Returns a json array of device information
@@ -220,7 +220,7 @@ async fn activate_one_click(
         .ok_or_else(|| anyhow::anyhow!("AWS IoT client is not available"))
         .map_err(generic)?;
 
-    iot.activate_one_click(&item).await.map_err(generic)?;
+    iot.activate_one_click(item).await.map_err(generic)?;
 
     Ok(response_with_code(StatusCode::OK, "ok"))
 }

--- a/src/service/iot.rs
+++ b/src/service/iot.rs
@@ -426,7 +426,7 @@ async fn run_iot_subscriber(
                                                     g: nl.g,
                                                     b: nl.b,
                                                 };
-                                                device.set_nightlight_state(nl.clone());
+                                                device.set_nightlight_state(nl);
                                             }
                                             GoveeBlePacket::NotifyHumidifierAutoMode(
                                                 HumidifierAutoMode { target_humidity },

--- a/src/service/quirks.rs
+++ b/src/service/quirks.rs
@@ -12,6 +12,7 @@ pub enum HumidityUnits {
 }
 
 impl HumidityUnits {
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_reading_to_relative_percent(&self, value: f64) -> f64 {
         match self {
             Self::RelativePercent => value,

--- a/src/service/state.rs
+++ b/src/service/state.rs
@@ -470,7 +470,7 @@ impl State {
         apply: F,
     ) -> anyhow::Result<bool> {
         let mut params: SetHumidifierNightlightParams =
-            device.nightlight_state.clone().unwrap_or_default().into();
+            device.nightlight_state.unwrap_or_default().into();
         (apply)(&mut params);
 
         if let Ok(command) = Base64HexBytes::encode_for_sku(&device.sku, &params) {
@@ -680,7 +680,7 @@ impl State {
     // Take care not to call this while you hold a mutable device
     // reference, as that will deadlock!
     pub async fn notify_of_state_change(self: &Arc<Self>, device_id: &str) -> anyhow::Result<()> {
-        let Some(canonical_device) = self.device_by_id(&device_id).await else {
+        let Some(canonical_device) = self.device_by_id(device_id).await else {
             anyhow::bail!("cannot find device {device_id}!?");
         };
 

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -149,7 +149,7 @@ impl TemperatureValue {
 
     pub fn as_unit(&self, unit: TemperatureUnits) -> Self {
         if self.unit == unit {
-            return self.clone();
+            return *self;
         }
 
         let normalized = self.value / self.unit.factor();
@@ -196,7 +196,7 @@ fn atoi<F: FromStr>(input: &str) -> Result<(F, &str), <F as FromStr>::Err> {
     let input = input.trim();
     let i = input
         .find(|c: char| !c.is_numeric() && c != '.')
-        .unwrap_or_else(|| input.len());
+        .unwrap_or(input.len());
     let number = input[..i].parse::<F>()?;
     Ok((number, input[i..].trim()))
 }

--- a/src/undoc_api.rs
+++ b/src/undoc_api.rs
@@ -390,7 +390,7 @@ impl GoveeUndocumentedApi {
 
         for c in catalog {
             for s in c.scenes {
-                if let Some(param_id) = s.light_effects.get(0).map(|e| e.scence_param_id) {
+                if let Some(param_id) = s.light_effects.first().map(|e| e.scence_param_id) {
                     options.push(EnumOption {
                         name: s.scene_name,
                         value: json!({


### PR DESCRIPTION
## What

Fix every clippy warning in the codebase so the project passes `cargo clippy --all -- -D warnings` cleanly.

27 files changed, +131/-164 lines. All changes are mechanical. Zero behavioral impact.

## Why

Clippy warnings accumulate and mask real issues. A clean baseline means new warnings from future PRs are immediately visible. This also unblocks adding `clippy -- -D warnings` to CI if desired.

## Changes by category

**Unnecessary borrows (64 sites)**
Remove `&` where the compiler auto-borrows. Clippy lints: `needless_borrow`, `needless_borrows_for_generic_args`.
```rust
// Before                          // After
state.poll_iot_api(&device)        state.poll_iot_api(device)
client.set_segment_brightness(&info, ..)  client.set_segment_brightness(info, ..)
.args(&["a", "b"])                 .args(["a", "b"])
```

**Pattern matching cleanup (7 sites)**
- `match { X => ..., _ => {} }` → `if let X = ...`
- `match { A => true, _ => false }` → `matches!(..)`
- Collapse duplicate arms: `"H7131" => { .. } "H7173" => { .. }` → `"H7131" | "H7173" => { .. }`

**Idiomatic replacements (8 sites)**
- `.get(0)` → `.first()`
- `unwrap_or_else(|| val)` → `unwrap_or(val)` (non-closure)
- `== ""` → `.is_empty()`
- `return self.clone()` → `return *self` (Copy type)
- `.filter_map(|x| if cond { Some(x) } else { None })` → `.filter(|x| cond)`
- `.map(|x| side_effect)` → `if let Some(x) = ... { side_effect }`

**From/Into (2 sites)**
Replace `impl Into<X> for Y` with `impl From<Y> for X` (gives `Into` for free).

**Lifetime elision (2 sites)**
Remove unused `<'a>` from `entities_for_work_mode` and elide explicit lifetime in `enumerate_entities_for_device`.

**Interior mutability (1 site)**
`pub const POLL_INTERVAL: Lazy<..>` → `pub static POLL_INTERVAL: Lazy<..>` (Lazy has interior mutability).

**Intentional #[allow] annotations (3 sites)**
Where the clippy suggestion would be a breaking API change or mischaracterizes intent:
- `#[allow(clippy::type_complexity)]` on `PacketCodec` — the boxed trait objects are inherent to the design
- `#[allow(clippy::wrong_self_convention)]` on `from_reading_to_relative_percent` — `from_*` taking `&self` is intentional here (it's a unit converter, not a constructor)
- `#[allow(clippy::enum_variant_names)]` on `SubCommand` — the `OneClick` suffix is the domain term

**Other**
- Field init shorthand: `state_class: state_class` → `state_class`
- Manual assign: `expect = expect + 1` → `expect += 1`

## Testing

- `cargo build --all` ✅
- `cargo test --all` — 31 passed, 0 failed ✅
- `cargo clippy --all -- -D warnings` — 0 warnings ✅
- `cargo fmt --all -- --check` ✅