### PR TITLE
fix: remove dangerous client id

### DIFF
--- a/src/service/hass.rs
+++ b/src/service/hass.rs
@@ -618,7 +618,7 @@ pub async fn spawn_hass_integration(
     args: &HassArguments,
 ) -> anyhow::Result<()> {
     let client = Client::with_id(
-        &format!("govee2mqtt/{}", uuid::Uuid::new_v4().simple()),
+        &format!("govee2mqtt-{}", uuid::Uuid::new_v4().simple()),
         true,
     )?;
 


### PR DESCRIPTION
Changes client id from govee2mqtt/ to govee2mqtt-

Closes #659