### PR TITLE
feat: add options to disable or filter published effect lists

### DIFF
--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -43,3 +43,5 @@ schema:
   broadcast_all: "bool?"
   global_broadcast: "bool?"
   scan: "str?"
+  disable_effects: "bool?"
+  allowed_effects: "str?"

--- a/addon/run.sh
+++ b/addon/run.sh
@@ -87,6 +87,14 @@ if bashio::config.has_value temperature_scale ; then
   export GOVEE_TEMPERATURE_SCALE="$(bashio::config temperature_scale)"
 fi
 
+if bashio::config.has_value disable_effects ; then
+  export GOVEE_DISABLE_EFFECTS="$(bashio::config disable_effects)"
+fi
+
+if bashio::config.has_value allowed_effects ; then
+  export GOVEE_ALLOWED_EFFECTS="$(bashio::config allowed_effects)"
+fi
+
 env | grep GOVEE_ | sed -r 's/_(EMAIL|KEY|PASSWORD)=.*/_\1=REDACTED/'
 set -x
 

--- a/addon/translations/en.yaml
+++ b/addon/translations/en.yaml
@@ -89,6 +89,17 @@ configuration:
       global broadcast address 255.255.255.255. To be honest, if
       multicast-UDP doesn't work, this isn't likely to work any
       better.
+  disable_effects:
+    name: Disable Effects
+    description: >-
+      Set to true to disable publishing effect lists for all devices to MQTT discovery.
+      This can fix issues with the Google Home Integration payload limits.
+  allowed_effects:
+    name: Allowed Effects
+    description: >-
+      A comma-separated list of effect names to allow (e.g. "Aurora,Rainbow").
+      If set, only effects matching these names will be published to MQTT discovery.
+      This helps reduce the payload size while still allowing some effects.
 
 
 

--- a/src/hass_mqtt/light.rs
+++ b/src/hass_mqtt/light.rs
@@ -161,14 +161,39 @@ impl DeviceLight {
         let effect_list = if segment.is_some() {
             vec![]
         } else {
-            match state.device_list_scenes(device).await {
-                Ok(scenes) => scenes,
-                Err(err) => {
-                    log::error!("Unable to list scenes for {device}: {err:#}");
-                    vec![]
+            let disable_effects = std::env::var("GOVEE_DISABLE_EFFECTS")
+                .map(|v| v == "true")
+                .unwrap_or(false);
+
+            if disable_effects {
+                vec![]
+            } else {
+                let mut scenes = match state.device_list_scenes(device).await {
+                    Ok(scenes) => scenes,
+                    Err(err) => {
+                        log::error!("Unable to list scenes for {device}: {err:#}");
+                        vec![]
+                    }
+                };
+
+                if let Ok(allowed) = std::env::var("GOVEE_ALLOWED_EFFECTS") {
+                    let allowed_list: Vec<String> = allowed
+                        .split(',')
+                        .map(|s| s.trim().to_lowercase())
+                        .collect();
+
+                    scenes.retain(|s| {
+                        !s.is_empty() && allowed_list.contains(&s.to_lowercase())
+                    });
+                } else {
+                    scenes.retain(|s| !s.is_empty());
                 }
+
+                scenes
             }
         };
+
+        let effect = !effect_list.is_empty();
 
         let mut supported_color_modes = vec![];
 
@@ -222,7 +247,7 @@ impl DeviceLight {
                 supported_color_modes,
                 brightness,
                 brightness_scale: 100,
-                effect: true,
+                effect,
                 effect_list,
                 payload_available: "online".to_string(),
                 max_mireds,


### PR DESCRIPTION
## Summary

Related to open issue: https://github.com/wez/govee2mqtt/issues/613

Adds `disable_effects` and `allowed_effects` configuration options to the Home Assistant addon, mapped to `GOVEE_DISABLE_EFFECTS` and `GOVEE_ALLOWED_EFFECTS` environment variables.

## Problem

The Home Assistant Google Assistant integration fails to sync devices to Google Home when the effect list exceeds Google's Home Graph API payload limits. Users with many Govee devices and scenes hit this ceiling, breaking the sync entirely.

## Changes

- **`GOVEE_DISABLE_EFFECTS`** (`bool`): When `true`, suppresses all effect lists from MQTT discovery payloads.
- **`GOVEE_ALLOWED_EFFECTS`** (`str`): Comma-separated allowlist of effect names (e.g. `"Aurora,Rainbow"`). Only matching effects are published, reducing payload size while retaining selected effects.
- When effects are fully disabled or the filtered list is empty, `effect: false` is reported to Home Assistant (previously always `true`).

## Files Changed

- `addon/config.yaml` — schema entries for new options
- `addon/run.sh` — env var passthrough from addon config
- `addon/translations/en.yaml` — user-facing descriptions
- `src/hass_mqtt/light.rs` — filtering logic and conditional `effect` flag

## Screenshot
<img width="1050" height="898" alt="Screenshot 2026-04-15 at 11 35 24" src="https://github.com/user-attachments/assets/1bd4701a-23bc-4f9d-b893-2d31cd9cdd72" />

