### PR TITLE
fix: treat unexpected MQTT loop exit as failure (exit 1) so HA supervisor restarts

### DIFF
--- a/src/service/hass.rs
+++ b/src/service/hass.rs
@@ -687,8 +687,10 @@ pub async fn spawn_hass_integration(
             tokio::time::sleep(tokio::time::Duration::from_secs(30)).await;
             std::process::exit(1);
         } else {
-            log::info!("run_mqtt_loop exited. We should do something to shutdown gracefully here");
-            std::process::exit(0);
+            log::error!(
+                "run_mqtt_loop exited unexpectedly. Terminating so HA can restart the addon."
+            );
+            std::process::exit(1);
         }
     });
 


### PR DESCRIPTION
## Problem

`spawn_hass_integration` calls `std::process::exit(0)` when `run_mqtt_loop` returns `Ok(())`. HA supervisor reads exit code 0 as "clean shutdown, do not restart," so the addon stays dead until a manual restart.

## Why `Ok(())` here is not a clean shutdown

In `run_mqtt_loop`:

```rust
while let Ok(event) = subscriber.recv().await {
    ...
}

Ok(())
```

The `while let Ok(...) = subscriber.recv().await` loop exits `Ok(())` only when `recv()` returns `Err` — i.e., the event channel has closed. That's the event pump dying, not a user-requested shutdown. There is currently no explicit shutdown path that reaches this branch.

## Fix

```diff
-            log::info!("run_mqtt_loop exited. We should do something to shutdown gracefully here");
-            std::process::exit(0);
+            log::error!(
+                "run_mqtt_loop exited unexpectedly. Terminating so HA can restart the addon."
+            );
+            std::process::exit(1);
```

## Not addressed

The existing code comment on this branch flags a bigger design gap: there's no explicit graceful-shutdown path (SIGTERM handler, cancellation token). This PR does not fix that — it only makes the supervisor do the right thing when the failure mode occurs. A follow-up PR can wire a real shutdown path, at which point the two exit codes can be distinguished properly.

## Scope

1 file, `src/service/hass.rs`, +4 / -2 lines.

## Verification

```
cargo build --all
cargo test --all   # 31 passed
cargo clippy --all -- -D warnings
cargo fmt --all -- --check
```

All pass.

Follow-up to #654 (closed).