### PR TITLE
Avoid polling after segmented light commands

### DIFF
--- a/src/service/coordinator.rs
+++ b/src/service/coordinator.rs
@@ -23,7 +23,7 @@ pub struct Coordinator {
     #[allow(unused)]
     permit: OwnedSemaphorePermit,
     #[allow(unused)]
-    trigger_poll: OneShotSender<()>,
+    trigger_poll: Option<OneShotSender<()>>,
 }
 
 impl Coordinator {
@@ -35,7 +35,15 @@ impl Coordinator {
         Self {
             device,
             permit,
-            trigger_poll,
+            trigger_poll: Some(trigger_poll),
+        }
+    }
+
+    pub fn new_without_poll(device: Device, permit: OwnedSemaphorePermit) -> Self {
+        Self {
+            device,
+            permit,
+            trigger_poll: None,
         }
     }
 }

--- a/src/service/hass.rs
+++ b/src/service/hass.rs
@@ -355,7 +355,7 @@ async fn mqtt_light_segment_command(
     Params(IdAndSeg { id, segment }): Params<IdAndSeg>,
     State(state): State<StateHandle>,
 ) -> anyhow::Result<()> {
-    let device = state.resolve_device_for_control(&id).await?;
+    let device = state.resolve_device_for_control_without_poll(&id).await?;
     let segment: u32 = segment.parse()?;
 
     let command: HassLightCommand = from_json(&payload)?;

--- a/src/service/state.rs
+++ b/src/service/state.rs
@@ -118,6 +118,26 @@ impl State {
         Ok(Coordinator::new(device, permit, tx))
     }
 
+    /// Resolve a device for serialized control without scheduling a follow-up poll.
+    ///
+    /// Segment color/brightness commands are optimistic in Home Assistant. Polling
+    /// the platform API after each segment update returns only a device-level light
+    /// state rather than the per-segment state, which can make Home Assistant and
+    /// subsequent controls reconcile against misleading whole-device color data.
+    pub async fn resolve_device_for_control_without_poll(
+        self: &Arc<Self>,
+        label: &str,
+    ) -> anyhow::Result<Coordinator> {
+        let device = self
+            .resolve_device(label)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("device '{label}' not found"))?;
+        let semaphore = self.semaphore_for_device(&device).await;
+        let permit = semaphore.acquire_owned().await?;
+
+        Ok(Coordinator::new_without_poll(device, permit))
+    }
+
     /// Resolve a device using its name, computed name, id or label,
     /// ignoring case.
     pub async fn resolve_device(&self, label: &str) -> Option<Device> {


### PR DESCRIPTION
## Summary

Avoid scheduling the follow-up Platform API state poll after segmented light commands.

Segmented light entities are already configured as optimistic in Home Assistant. After a segment color/brightness command, the bridge currently schedules the same post-control poll used for whole-device commands. For segmented devices, that Platform API poll reports only a device-level light state, not per-segment state. Reconciling immediately against that simplified state can make Home Assistant and subsequent controls treat a single whole-device color as authoritative after segment updates.

This change keeps the existing per-device serialization for segment commands, but skips the post-control poll for those segment commands.

## Why

Observed with a segmented Govee light device:

1. Home Assistant sends a command to a segment entity.
2. govee2mqtt sends `segmentedBrightness` / `segmentedColorRgb` through the Platform API.
3. The Platform API returns success.
4. govee2mqtt schedules a post-control poll.
5. The poll returns a single device-level `DeviceState.color`, not the per-segment layout.
6. That state is reconciled as the device's current light state even though the command was segment-specific.

Sanitized log excerpt:

```text
INFO service::hass  Command for <segmented-device> segment <n>: {"state":"ON","color":{"r":...,"g":...,"b":...},"brightness":...}
INFO service::hass  Using Platform API to control <segmented-device> segment
INFO platform_api   control_device result: code=200, message="success", capability=SegmentColorSetting(instance="segmentedBrightness")
INFO platform_api   control_device result: code=200, message="success", capability=SegmentColorSetting(instance="segmentedColorRgb")
INFO service::state Polling <segmented-device> to get latest state after control
INFO service::state requesting update via Platform API <segmented-device> Some(DeviceState { color: DeviceColor { r: ..., g: ..., b: ... }, brightness: ..., source: "PLATFORM API", ... })
```

The important detail is that the segment commands succeed, but the immediate poll only reports a whole-device color state.

## Change

- Add a `Coordinator::new_without_poll` constructor.
- Add `State::resolve_device_for_control_without_poll` to keep the serialization lock without scheduling the delayed state poll.
- Use the no-poll control path for `mqtt_light_segment_command`.

Whole-device commands still use the existing post-control polling behavior.

## Validation

Locally passed:

```text
cargo fmt --all -- --check
cargo test --all -- --show-output
cargo build --all
```
