### PR TITLE
feat: surface Govee cloud device events to Home Assistant

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -66,3 +66,31 @@ You will also need to configure `govee2mqtt` to use the same broker:
 |`--mqtt-username`|`GOVEE_MQTT_USER`|`mqtt_username`|If your broker requires authentication, the username to use|
 |`--mqtt-password`|`GOVEE_MQTT_PASSWORD`|`mqtt_password`|If your broker requires authentication, the password to use|
 
+## Device Events
+
+Some Govee devices emit *events* rather than ongoing state. Examples include
+the ice-maker-full and water-empty notifications on the H7172 ice maker, and
+presence/absence on presence sensors such as the H5127.
+
+When a Govee API Key is configured, `govee2mqtt` subscribes directly to Govee's
+cloud MQTT broker (`mqtt.openapi.govee.com`) and republishes these events to
+Home Assistant as
+[MQTT `event` entities](https://www.home-assistant.io/integrations/event.mqtt/).
+This removes the need for the manual Mosquitto bridge workaround described in
+[issue #343](https://github.com/wez/govee2mqtt/issues/343); the relevant event
+entities are created automatically as part of the normal discovery process.
+
+This feature is enabled automatically whenever an API Key is present and the
+device advertises an event capability. The connection is supervised and will
+reconnect automatically (with exponential backoff) if it is dropped.
+
+|CLI|ENV|Purpose|
+|---|---|-------|
+|`--disable-platform-mqtt`|`GOVEE_DISABLE_PLATFORM_MQTT=true`|Disable subscribing to Govee's cloud MQTT broker for device events.|
+|`--platform-mqtt-ca`|`GOVEE_MQTT_PLATFORM_CA`|Path to a CA certificate file, or a directory of CA certificates, used to validate the TLS connection to Govee's cloud MQTT broker. Defaults to autodetecting the system CA bundle, which is correct for the official container image and Home Assistant Add-on.|
+
+*The events delivered here are momentary. If `govee2mqtt` is restarted or
+briefly disconnected, any events that occur during that window are missed; this
+is a limitation of the Govee cloud and applies equally to the manual bridge
+workaround.*
+

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -4,6 +4,7 @@ use crate::service::device::Device;
 use crate::service::hass::spawn_hass_integration;
 use crate::service::http::run_http_server;
 use crate::service::iot::start_iot_client;
+use crate::service::platform_mqtt::{resolve_ca_location, start_platform_mqtt_client};
 use crate::service::state::StateHandle;
 use crate::undoc_api::GoveeUndocumentedApi;
 use crate::version_info::govee_version;
@@ -349,6 +350,25 @@ impl ServeCommand {
 
         // start advertising on local mqtt
         spawn_hass_integration(state.clone(), &args.hass_args).await?;
+
+        // Subscribe to Govee's cloud MQTT broker for device events (eg:
+        // ice-maker-full, water-empty, presence). This needs the platform API
+        // key and is what surfaces those events to Home Assistant without
+        // requiring a separate Mosquitto bridge.
+        // <https://github.com/wez/govee2mqtt/issues/343>
+        if state.get_platform_client().await.is_some() && args.api_args.platform_mqtt_enabled() {
+            match args.api_args.api_key() {
+                Ok(api_key) => match resolve_ca_location(args.api_args.platform_mqtt_ca.clone()) {
+                    Ok(ca) => start_platform_mqtt_client(api_key, state.clone(), ca),
+                    Err(err) => {
+                        log::error!("platform MQTT: not subscribing to device events: {err:#}")
+                    }
+                },
+                Err(err) => {
+                    log::warn!("platform MQTT: no API key available; not subscribing: {err:#}")
+                }
+            }
+        }
 
         run_http_server(state.clone(), self.http_port)
             .await

--- a/src/hass_mqtt/enumerator.rs
+++ b/src/hass_mqtt/enumerator.rs
@@ -1,6 +1,7 @@
 use crate::hass_mqtt::base::{Device, EntityConfig, Origin};
 use crate::hass_mqtt::button::ButtonConfig;
 use crate::hass_mqtt::climate::TargetTemperatureEntity;
+use crate::hass_mqtt::event::EventConfig;
 use crate::hass_mqtt::humidifier::Humidifier;
 use crate::hass_mqtt::instance::EntityList;
 use crate::hass_mqtt::light::DeviceLight;
@@ -182,9 +183,17 @@ pub async fn enumerate_entities_for_device(
                 DeviceCapabilityKind::ColorSetting
                 | DeviceCapabilityKind::SegmentColorSetting
                 | DeviceCapabilityKind::MusicSetting
-                | DeviceCapabilityKind::Event
                 | DeviceCapabilityKind::Mode
                 | DeviceCapabilityKind::DynamicScene => {}
+
+                DeviceCapabilityKind::Event => {
+                    // Devices that publish events (eg: ice-maker-full,
+                    // water-empty, presence) expose them via Govee's cloud
+                    // MQTT broker; see service::platform_mqtt.
+                    if let Some(event) = EventConfig::new(d, cap) {
+                        entities.add(event);
+                    }
+                }
 
                 DeviceCapabilityKind::Range if cap.instance == "brightness" => {}
                 DeviceCapabilityKind::Range if cap.instance == "humidity" => {}

--- a/src/hass_mqtt/event.rs
+++ b/src/hass_mqtt/event.rs
@@ -1,0 +1,289 @@
+use crate::hass_mqtt::base::{Device, EntityConfig, Origin};
+use crate::hass_mqtt::instance::{publish_entity_config, EntityInstance};
+use crate::platform_api::DeviceCapability;
+use crate::service::device::Device as ServiceDevice;
+use crate::service::hass::{
+    availability_topic, camel_case_to_space_separated, event_state_topic, topic_safe_id,
+    topic_safe_string, HassClient,
+};
+use crate::service::state::StateHandle;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use std::collections::HashMap;
+
+/// Information about an event-type capability, derived from the `eventState`
+/// metadata returned for the device by the Govee platform API.
+#[derive(Debug, Clone)]
+pub struct EventCapabilityInfo {
+    /// The list of distinct event type labels that this capability can emit.
+    /// Home Assistant requires this to be declared up front when configuring
+    /// an MQTT `event` entity.
+    pub event_types: Vec<String>,
+    /// Maps a normalized capability state value to its event type label, so
+    /// that incoming event values can be matched back to a declared event
+    /// type regardless of the human-readable name/message in the payload.
+    pub label_by_value: HashMap<String, String>,
+}
+
+#[derive(Deserialize, Debug)]
+struct EventStateMeta {
+    #[serde(default)]
+    options: Vec<EventOptionMeta>,
+}
+
+#[derive(Deserialize, Debug)]
+struct EventOptionMeta {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    value: JsonValue,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+/// Normalize a capability state value into a stable string key so that
+/// incoming event values can be matched against the metadata options
+/// regardless of whether the value is encoded as an integer or a string
+/// (eg: the integer `1` and the string `"1"` map to the same key).
+pub fn value_key(value: &JsonValue) -> String {
+    if let Some(i) = value.as_i64() {
+        i.to_string()
+    } else if let Some(s) = value.as_str() {
+        s.to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+/// Compute the human-facing event type label for an option or incoming
+/// state entry. Prefers the `message` field when it is present and
+/// non-empty, otherwise falls back to the `name` field.
+pub fn event_type_label(name: &str, message: Option<&str>) -> String {
+    match message {
+        Some(m) if !m.is_empty() => m.to_string(),
+        _ => name.to_string(),
+    }
+}
+
+/// Parse the `eventState` metadata for an event capability into the set of
+/// possible event types and a value->label lookup table.
+/// Returns `None` if the capability has no usable event metadata.
+pub fn parse_event_capability(cap: &DeviceCapability) -> Option<EventCapabilityInfo> {
+    let event_state = cap.event_state.as_ref()?;
+    let meta: EventStateMeta = serde_json::from_value(event_state.clone()).ok()?;
+
+    let mut event_types: Vec<String> = vec![];
+    let mut label_by_value = HashMap::new();
+
+    for opt in &meta.options {
+        let label = event_type_label(&opt.name, opt.message.as_deref());
+        if label.is_empty() {
+            continue;
+        }
+        if !event_types.contains(&label) {
+            event_types.push(label.clone());
+        }
+        if !opt.value.is_null() {
+            label_by_value.insert(value_key(&opt.value), label);
+        }
+    }
+
+    if event_types.is_empty() {
+        return None;
+    }
+
+    Some(EventCapabilityInfo {
+        event_types,
+        label_by_value,
+    })
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct EventConfig {
+    #[serde(flatten)]
+    pub base: EntityConfig,
+
+    pub state_topic: String,
+    pub event_types: Vec<String>,
+}
+
+/// Friendly name and icon for an event capability. Govee's instance names
+/// are terse and inconsistent, so map the well-known ones to nicer names and
+/// icons. Anything unknown falls back to a humanized version of the instance
+/// name (with a trailing "Event" stripped) and no icon.
+fn event_presentation(instance: &str) -> (String, Option<&'static str>) {
+    match instance {
+        "iceFull" => ("Ice Maker Full".to_string(), Some("mdi:bucket")),
+        "lackWaterEvent" => ("Out of Water".to_string(), Some("mdi:water-alert-outline")),
+        _ => {
+            // Drop a trailing `Event` so eg: `lackWaterEvent` -> "Lack Water".
+            let label = instance.strip_suffix("Event").unwrap_or(instance);
+            (camel_case_to_space_separated(label), None)
+        }
+    }
+}
+
+impl EventConfig {
+    /// Create an event entity for the given event capability, if it has
+    /// usable metadata. Returns `None` when no event types can be derived,
+    /// since Home Assistant rejects event entities without an
+    /// `event_types` list.
+    pub fn new(device: &ServiceDevice, cap: &DeviceCapability) -> Option<Self> {
+        let info = parse_event_capability(cap)?;
+
+        let unique_id = format!(
+            "gv2mqtt-{id}-event-{inst}",
+            id = topic_safe_id(device),
+            inst = topic_safe_string(&cap.instance)
+        );
+
+        let (name, icon) = event_presentation(&cap.instance);
+
+        Some(Self {
+            base: EntityConfig {
+                availability_topic: availability_topic(),
+                name: Some(name),
+                entity_category: None,
+                origin: Origin::default(),
+                device: Device::for_device(device),
+                unique_id,
+                device_class: None,
+                icon: icon.map(|s| s.to_string()),
+            },
+            state_topic: event_state_topic(device, &cap.instance),
+            event_types: info.event_types,
+        })
+    }
+}
+
+#[async_trait]
+impl EntityInstance for EventConfig {
+    async fn publish_config(&self, state: &StateHandle, client: &HassClient) -> anyhow::Result<()> {
+        publish_entity_config("event", state, client, &self.base, self).await
+    }
+
+    async fn notify_state(&self, _client: &HassClient) -> anyhow::Result<()> {
+        // Events are momentary and have no persistent state to publish
+        // during the regular notification cycle. Event states are published
+        // by the platform MQTT subscriber when events actually arrive.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::platform_api::from_json;
+
+    fn cap(json: &str) -> DeviceCapability {
+        from_json(json).unwrap()
+    }
+
+    #[test]
+    fn parse_lack_water_event() {
+        let cap = cap(r#"{
+                "type": "devices.capabilities.event",
+                "instance": "lackWaterEvent",
+                "alarmType": 51,
+                "eventState": {
+                    "options": [
+                        {"name": "lack", "value": 1, "message": "Lack of Water"}
+                    ]
+                }
+            }"#);
+        let info = parse_event_capability(&cap).expect("usable metadata");
+        assert_eq!(info.event_types, vec!["Lack of Water".to_string()]);
+        assert_eq!(
+            info.label_by_value.get("1"),
+            Some(&"Lack of Water".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_presence_event_without_message() {
+        let cap = cap(r#"{
+                "type": "devices.capabilities.event",
+                "instance": "bodyAppearedEvent",
+                "eventState": {
+                    "options": [
+                        {"name": "Presence", "value": 1},
+                        {"name": "Absence", "value": 2}
+                    ]
+                }
+            }"#);
+        let info = parse_event_capability(&cap).expect("usable metadata");
+        assert_eq!(
+            info.event_types,
+            vec!["Presence".to_string(), "Absence".to_string()]
+        );
+        assert_eq!(info.label_by_value.get("1"), Some(&"Presence".to_string()));
+        assert_eq!(info.label_by_value.get("2"), Some(&"Absence".to_string()));
+    }
+
+    #[test]
+    fn parse_event_without_options_is_none() {
+        let cap = cap(r#"{
+                "type": "devices.capabilities.event",
+                "instance": "someEvent",
+                "eventState": {"options": []}
+            }"#);
+        assert!(parse_event_capability(&cap).is_none());
+    }
+
+    #[test]
+    fn value_key_normalizes() {
+        assert_eq!(value_key(&serde_json::json!(1)), "1");
+        assert_eq!(value_key(&serde_json::json!("abc")), "abc");
+        // An integer and its string form normalize to the same key.
+        assert_eq!(
+            value_key(&serde_json::json!(1)),
+            value_key(&serde_json::json!("1"))
+        );
+    }
+
+    #[test]
+    fn label_prefers_message() {
+        assert_eq!(
+            event_type_label("lack", Some("Lack of Water")),
+            "Lack of Water"
+        );
+        assert_eq!(event_type_label("Presence", None), "Presence");
+        assert_eq!(event_type_label("Presence", Some("")), "Presence");
+    }
+
+    #[test]
+    fn presentation_known_and_fallback() {
+        assert_eq!(
+            event_presentation("iceFull"),
+            ("Ice Maker Full".to_string(), Some("mdi:bucket"))
+        );
+        assert_eq!(
+            event_presentation("lackWaterEvent"),
+            ("Out of Water".to_string(), Some("mdi:water-alert-outline"))
+        );
+        // Unknown instance: humanized name, trailing "Event" dropped, no icon.
+        assert_eq!(
+            event_presentation("bodyAppearedEvent"),
+            ("Body Appeared".to_string(), None)
+        );
+    }
+
+    #[test]
+    fn event_config_uses_friendly_name_and_icon() {
+        let device = ServiceDevice::new("H7172", "9A:52:60:74:F4:48:A5:DE");
+        let cap = cap(r#"{
+                "type": "devices.capabilities.event",
+                "instance": "iceFull",
+                "eventState": {
+                    "options": [
+                        {"name": "iceFull", "value": 1, "message": "ice maker full"}
+                    ]
+                }
+            }"#);
+        let ev = EventConfig::new(&device, &cap).expect("entity");
+        assert_eq!(ev.base.name.as_deref(), Some("Ice Maker Full"));
+        assert_eq!(ev.base.icon.as_deref(), Some("mdi:bucket"));
+        assert_eq!(ev.event_types, vec!["ice maker full".to_string()]);
+    }
+}

--- a/src/hass_mqtt/mod.rs
+++ b/src/hass_mqtt/mod.rs
@@ -3,6 +3,7 @@ pub mod button;
 pub mod climate;
 pub mod cover;
 pub mod enumerator;
+pub mod event;
 pub mod humidifier;
 pub mod instance;
 pub mod light;

--- a/src/platform_api.rs
+++ b/src/platform_api.rs
@@ -33,6 +33,20 @@ pub struct GoveeApiArguments {
     /// the GOVEE_API_KEY environment variable.
     #[arg(long, global = true)]
     pub api_key: Option<String>,
+
+    /// Disable subscribing to Govee's cloud MQTT broker that delivers
+    /// device events such as ice-maker-full, water-empty and presence
+    /// detection. You may also set GOVEE_DISABLE_PLATFORM_MQTT=true via
+    /// the environment.
+    #[arg(long, global = true)]
+    pub disable_platform_mqtt: bool,
+
+    /// Path to a CA certificate file, or a directory of CA certificates,
+    /// used to validate the TLS connection to Govee's cloud MQTT broker.
+    /// Defaults to autodetecting the system CA bundle. You may also set
+    /// GOVEE_MQTT_PLATFORM_CA via the environment.
+    #[arg(long, global = true)]
+    pub platform_mqtt_ca: Option<std::path::PathBuf>,
 }
 
 impl GoveeApiArguments {
@@ -55,6 +69,25 @@ impl GoveeApiArguments {
     pub fn api_client(&self) -> anyhow::Result<GoveeApiClient> {
         let key = self.api_key()?;
         Ok(GoveeApiClient::new(key))
+    }
+
+    /// Whether the Govee cloud MQTT event subscription should be enabled.
+    /// Enabled by default; can be turned off via the --disable-platform-mqtt
+    /// flag or the GOVEE_DISABLE_PLATFORM_MQTT environment variable.
+    /// A misconfigured toggle should not take down the service, so any error
+    /// reading the environment variable is logged and treated as enabled.
+    pub fn platform_mqtt_enabled(&self) -> bool {
+        if self.disable_platform_mqtt {
+            return false;
+        }
+        match opt_env_var::<String>("GOVEE_DISABLE_PLATFORM_MQTT") {
+            Ok(Some(v)) => !crate::lan_api::truthy(&v).unwrap_or(false),
+            Ok(None) => true,
+            Err(err) => {
+                log::warn!("ignoring invalid GOVEE_DISABLE_PLATFORM_MQTT: {err:#}");
+                true
+            }
+        }
     }
 }
 

--- a/src/service/hass.rs
+++ b/src/service/hass.rs
@@ -211,6 +211,17 @@ pub fn light_state_topic(device: &ServiceDevice) -> String {
     format!("gv2mqtt/light/{id}/state", id = topic_safe_id(device))
 }
 
+/// The topic on which we publish event states for a device's event
+/// capability (eg: ice-maker-full, water-empty). The matching HASS event
+/// entity subscribes to this topic.
+pub fn event_state_topic(device: &ServiceDevice, instance: &str) -> String {
+    format!(
+        "gv2mqtt/event/{id}/{inst}/state",
+        id = topic_safe_id(device),
+        inst = topic_safe_string(instance)
+    )
+}
+
 pub fn light_segment_state_topic(device: &ServiceDevice, segment: u32) -> String {
     format!(
         "gv2mqtt/light/{id}/state/{segment}",

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -3,5 +3,6 @@ pub mod device;
 pub mod hass;
 pub mod http;
 pub mod iot;
+pub mod platform_mqtt;
 pub mod quirks;
 pub mod state;

--- a/src/service/platform_mqtt.rs
+++ b/src/service/platform_mqtt.rs
@@ -1,0 +1,578 @@
+//! Subscribes to Govee's cloud MQTT broker to receive device events such as
+//! ice-maker-full, water-empty and presence detection.
+//!
+//! This replaces the need to run a separate Mosquitto bridge as described in
+//! <https://github.com/wez/govee2mqtt/issues/343>. The broker, authentication
+//! and topic are documented at
+//! <https://developer.govee.com/reference/subscribe-device-event>:
+//!
+//! * Host: `mqtt.openapi.govee.com`, port 8883 (TLS)
+//! * Username and password are both the Govee API key
+//! * Topic is `GA/<api-key>`
+//!
+//! The connection is supervised so that it reconnects robustly: mosquitto's
+//! built-in auto-reconnect handles transient drops (re-subscribing on each
+//! reconnect), while an outer supervisor rebuilds the client from scratch,
+//! with exponential backoff, if the connection cannot be (re)established or
+//! is closed cleanly by the broker.
+
+use crate::hass_mqtt::event::{event_type_label, parse_event_capability, value_key};
+use crate::opt_env_var;
+use crate::platform_api::{from_json, DeviceCapabilityKind};
+use crate::service::device::Device;
+use crate::service::hass::event_state_topic;
+use crate::service::state::StateHandle;
+use anyhow::Context;
+use async_channel::Receiver;
+use chrono::Utc;
+use mosquitto_rs::{Client, Event, QoS};
+use parking_lot::Mutex;
+use serde::Deserialize;
+use serde_json::{json, Value as JsonValue};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::time::{sleep, timeout};
+
+const PLATFORM_MQTT_HOST: &str = "mqtt.openapi.govee.com";
+const PLATFORM_MQTT_PORT: i32 = 8883;
+
+/// Minimum interval between platform-API polls that are triggered by an
+/// incoming event message for a given device. This protects the (rate
+/// limited) Govee platform API from being hammered by chatty devices.
+const POLL_COOLDOWN: Duration = Duration::from_secs(60);
+
+const INITIAL_BACKOFF: Duration = Duration::from_secs(2);
+const MAX_BACKOFF: Duration = Duration::from_secs(300);
+/// If a connection stayed up for at least this long before dropping, treat it
+/// as healthy and reset the reconnect backoff.
+const HEALTHY_CONNECTION: Duration = Duration::from_secs(60);
+
+type PollCooldown = Arc<Mutex<HashMap<String, Instant>>>;
+
+/// Where to find the trust roots used to validate the TLS connection to the
+/// Govee MQTT broker.
+#[derive(Debug, Clone)]
+pub enum CaLocation {
+    /// A single PEM file containing one or more CA certificates.
+    File(PathBuf),
+    /// A directory of PEM-encoded CA certificates (OpenSSL c_rehash layout).
+    Path(PathBuf),
+}
+
+impl CaLocation {
+    fn configure(&self, client: &Client) -> anyhow::Result<()> {
+        match self {
+            CaLocation::File(file) => client.configure_tls(
+                Some(file),
+                None::<&Path>,
+                None::<&Path>,
+                None::<&Path>,
+                None,
+            ),
+            CaLocation::Path(dir) => {
+                client.configure_tls(None::<&Path>, Some(dir), None::<&Path>, None::<&Path>, None)
+            }
+        }
+        .context("configure_tls")
+    }
+}
+
+fn classify_ca(path: PathBuf) -> anyhow::Result<CaLocation> {
+    if path.is_dir() {
+        Ok(CaLocation::Path(path))
+    } else if path.exists() {
+        Ok(CaLocation::File(path))
+    } else {
+        anyhow::bail!("configured platform MQTT CA location {path:?} does not exist");
+    }
+}
+
+/// Resolve the CA trust store to use for the platform MQTT TLS connection.
+/// An explicit override (CLI argument or `GOVEE_MQTT_PLATFORM_CA`) wins;
+/// otherwise we autodetect the system CA bundle from common locations.
+pub fn resolve_ca_location(override_path: Option<PathBuf>) -> anyhow::Result<CaLocation> {
+    if let Some(path) = override_path {
+        return classify_ca(path);
+    }
+    if let Some(path) = opt_env_var::<PathBuf>("GOVEE_MQTT_PLATFORM_CA")? {
+        return classify_ca(path);
+    }
+
+    // Common system CA bundle file locations across distributions.
+    const CANDIDATE_FILES: &[&str] = &[
+        "/etc/ssl/certs/ca-certificates.crt", // Debian/Ubuntu/distroless
+        "/etc/pki/tls/certs/ca-bundle.crt",   // RHEL/Fedora/CentOS
+        "/etc/ssl/cert.pem",                  // Alpine/macOS/BSD
+    ];
+    for file in CANDIDATE_FILES {
+        let path = Path::new(file);
+        if path.exists() {
+            return Ok(CaLocation::File(path.to_path_buf()));
+        }
+    }
+
+    // Fall back to a directory of hashed certs.
+    let dir = Path::new("/etc/ssl/certs");
+    if dir.is_dir() {
+        return Ok(CaLocation::Path(dir.to_path_buf()));
+    }
+
+    anyhow::bail!(
+        "could not locate a system CA bundle for the platform MQTT TLS connection; \
+         set GOVEE_MQTT_PLATFORM_CA (or --platform-mqtt-ca) to point at your CA \
+         certificate file or directory"
+    );
+}
+
+/// A device event/state message published by the Govee platform MQTT broker.
+#[derive(Deserialize, Debug)]
+struct PlatformMessage {
+    device: Option<String>,
+    #[serde(default)]
+    capabilities: Vec<PlatformCapability>,
+}
+
+#[derive(Deserialize, Debug)]
+struct PlatformCapability {
+    #[serde(rename = "type")]
+    kind: DeviceCapabilityKind,
+    instance: String,
+    /// For event capabilities this is an array of state entries. We keep it
+    /// as a raw value so that messages carrying other (object-shaped) state
+    /// don't fail to parse.
+    #[serde(default)]
+    state: JsonValue,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct PlatformEventState {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    value: JsonValue,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+/// Start the supervised platform MQTT subscription as a background task.
+pub fn start_platform_mqtt_client(api_key: String, state: StateHandle, ca: CaLocation) {
+    tokio::spawn(async move {
+        let cooldown: PollCooldown = Arc::new(Mutex::new(HashMap::new()));
+        let mut backoff = INITIAL_BACKOFF;
+
+        loop {
+            let outcome = run_platform_mqtt_once(&state, &api_key, &ca, &cooldown).await;
+
+            // If we had a healthy, long-lived connection (measured from after
+            // the connection was actually established, not including connect
+            // time), reset the backoff so a single later drop reconnects
+            // promptly. Reset before logging/sleeping so the logged value and
+            // the actual delay agree.
+            if matches!(&outcome, Ok(uptime) if *uptime >= HEALTHY_CONNECTION) {
+                backoff = INITIAL_BACKOFF;
+            }
+
+            match outcome {
+                Ok(uptime) => {
+                    log::warn!(
+                        "platform MQTT: connection closed after {uptime:?}; \
+                         reconnecting in {backoff:?}"
+                    );
+                }
+                Err(err) => {
+                    log::error!("platform MQTT: {err:#}; retrying in {backoff:?}");
+                }
+            }
+
+            sleep(backoff).await;
+            backoff = (backoff * 2).min(MAX_BACKOFF);
+        }
+    });
+}
+
+/// Build a client and establish a fresh TLS+authenticated connection to the
+/// Govee platform MQTT broker. The returned client is connected but has not
+/// yet subscribed to any topics.
+async fn connect_platform_client(api_key: &str, ca: &CaLocation) -> anyhow::Result<Client> {
+    let client = Client::with_id(
+        &format!("gv2mqtt-platform-{}", uuid::Uuid::new_v4().simple()),
+        true,
+    )
+    .context("creating platform MQTT client")?;
+
+    // Back off exponentially (1s..60s) for mosquitto's own auto-reconnect
+    // between the explicit supervisor rebuilds.
+    client
+        .set_reconnect_delay(Duration::from_secs(1), Duration::from_secs(60), true)
+        .ok();
+
+    ca.configure(&client)
+        .context("configuring platform MQTT TLS")?;
+
+    client
+        .set_username_and_password(Some(api_key), Some(api_key))
+        .context("setting platform MQTT credentials")?;
+
+    log::info!("platform MQTT: connecting to {PLATFORM_MQTT_HOST}:{PLATFORM_MQTT_PORT}");
+    let status = timeout(
+        Duration::from_secs(60),
+        client.connect(
+            PLATFORM_MQTT_HOST,
+            PLATFORM_MQTT_PORT,
+            Duration::from_secs(90),
+            None,
+        ),
+    )
+    .await
+    .with_context(|| format!("timeout connecting to platform MQTT {PLATFORM_MQTT_HOST}"))?
+    .with_context(|| format!("failed to connect to platform MQTT {PLATFORM_MQTT_HOST}"))?;
+    log::info!("platform MQTT: connected, status={status}");
+
+    Ok(client)
+}
+
+/// Connect and run the subscriber loop until the connection is closed.
+/// On success, returns how long the connection was up *after* connecting,
+/// so the supervisor can distinguish a healthy session from connect-then-drop
+/// flapping.
+async fn run_platform_mqtt_once(
+    state: &StateHandle,
+    api_key: &str,
+    ca: &CaLocation,
+    cooldown: &PollCooldown,
+) -> anyhow::Result<Duration> {
+    let client = connect_platform_client(api_key, ca).await?;
+    let connected_at = Instant::now();
+
+    let subscriber = client
+        .subscriber()
+        .expect("first and only call to subscriber()");
+
+    run_platform_subscriber(
+        subscriber,
+        state.clone(),
+        client,
+        api_key.to_string(),
+        cooldown.clone(),
+    )
+    .await?;
+
+    Ok(connected_at.elapsed())
+}
+
+async fn run_platform_subscriber(
+    subscriber: Receiver<Event>,
+    state: StateHandle,
+    client: Client,
+    api_key: String,
+    cooldown: PollCooldown,
+) -> anyhow::Result<()> {
+    while let Ok(event) = subscriber.recv().await {
+        match event {
+            Event::Connected(status) => {
+                log::info!("platform MQTT: (re)connected with status {status}");
+
+                let topic = format!("GA/{api_key}");
+                if let Err(err) = client.subscribe(&topic, QoS::AtMostOnce).await {
+                    log::error!("platform MQTT: failed to subscribe to {topic}: {err:#}");
+                }
+                // The official documentation is internally inconsistent about
+                // whether the topic is `GA/<key>` or the bare `<key>`.
+                // Empirically it is `GA/<key>`, but subscribing to both is
+                // cheap insurance against either behavior.
+                if let Err(err) = client.subscribe(&api_key, QoS::AtMostOnce).await {
+                    log::debug!("platform MQTT: failed to subscribe to bare-key topic: {err:#}");
+                }
+            }
+            Event::Message(msg) => {
+                log::trace!(
+                    "platform MQTT: {} -> {}",
+                    msg.topic,
+                    String::from_utf8_lossy(&msg.payload)
+                );
+
+                // Publish events inline so that ordering is preserved (this
+                // matters for eg: presence appeared-then-absent). The publish
+                // path is fast; only the slow, rate-limited poll fallback is
+                // spawned off the loop (see handle_platform_message).
+                handle_platform_message(&state, &msg.payload, &cooldown).await;
+            }
+            Event::Disconnected(reason) => {
+                if reason.is_unexpected_disconnect() {
+                    log::warn!(
+                        "platform MQTT: disconnected with reason {reason}; \
+                         will attempt to auto-reconnect"
+                    );
+                } else {
+                    log::info!(
+                        "platform MQTT: broker closed the connection cleanly \
+                         (reason {reason}); rebuilding"
+                    );
+                }
+            }
+        }
+    }
+
+    // The channel closed: mosquitto will not auto-reconnect in this case
+    // (eg: a clean, broker-initiated disconnect). Returning lets the
+    // supervisor rebuild the client from scratch.
+    Ok(())
+}
+
+async fn handle_platform_message(state: &StateHandle, payload: &[u8], cooldown: &PollCooldown) {
+    let message: PlatformMessage = match from_json(payload) {
+        Ok(message) => message,
+        Err(err) => {
+            log::warn!("platform MQTT: failed to parse message: {err:#}");
+            return;
+        }
+    };
+
+    let Some(device_id) = message.device.as_deref() else {
+        log::trace!("platform MQTT: message has no device id; ignoring");
+        return;
+    };
+
+    let Some(device) = state.device_by_id(device_id).await else {
+        log::debug!("platform MQTT: event for unknown device {device_id}; ignoring");
+        return;
+    };
+
+    let hass = state.get_hass_client().await;
+    let mut need_poll = false;
+
+    for cap in &message.capabilities {
+        if cap.kind != DeviceCapabilityKind::Event {
+            // A non-event state update. The payload shape differs from the
+            // platform API state, so rather than try to apply it directly we
+            // refresh via a (debounced) poll, per the approach suggested in
+            // <https://github.com/wez/govee2mqtt/issues/343>.
+            need_poll = true;
+            continue;
+        }
+
+        let info = device
+            .get_capability_by_instance(&cap.instance)
+            .filter(|c| c.kind == DeviceCapabilityKind::Event)
+            .and_then(parse_event_capability);
+
+        let entries: Vec<PlatformEventState> =
+            serde_json::from_value(cap.state.clone()).unwrap_or_default();
+
+        match (&hass, &info) {
+            (Some(hass), Some(info)) => {
+                let topic = event_state_topic(&device, &cap.instance);
+                for entry in &entries {
+                    let event_type = info
+                        .label_by_value
+                        .get(&value_key(&entry.value))
+                        .cloned()
+                        .unwrap_or_else(|| event_type_label(&entry.name, entry.message.as_deref()));
+
+                    if !info.event_types.contains(&event_type) {
+                        log::warn!(
+                            "platform MQTT: event_type {event_type:?} for {device} {inst} \
+                             is not in the advertised list {types:?}; Home Assistant will \
+                             ignore it",
+                            inst = cap.instance,
+                            types = info.event_types
+                        );
+                    }
+
+                    log::info!(
+                        "platform MQTT: {device} {inst} event: {event_type}",
+                        inst = cap.instance
+                    );
+
+                    let payload = json!({
+                        "event_type": event_type,
+                        "name": entry.name,
+                        "value": entry.value,
+                        "message": entry.message,
+                    });
+
+                    if let Err(err) = hass.publish_obj(&topic, &payload).await {
+                        log::error!("platform MQTT: failed to publish event for {device}: {err:#}");
+                    }
+                }
+            }
+            _ => {
+                // Either HASS isn't connected yet, or we have no metadata to
+                // map this event onto an entity. Fall back to polling.
+                need_poll = true;
+            }
+        }
+    }
+
+    if need_poll {
+        // Offload the (potentially slow, rate-limited) poll so it cannot block
+        // the subscriber loop or delay/ reorder subsequent event publishes.
+        let state = state.clone();
+        let device = device.clone();
+        let cooldown = cooldown.clone();
+        tokio::spawn(async move {
+            maybe_poll_device(&state, &device, &cooldown).await;
+        });
+    }
+}
+
+async fn maybe_poll_device(state: &StateHandle, device: &Device, cooldown: &PollCooldown) {
+    // This poll is only ever a fallback (unmappable event, or HASS not yet
+    // ready). The Govee platform API is daily-quota limited, so only poll when
+    // the device's state is actually stale; an event should not force a poll on
+    // every message. This keeps the worst case in line with the normal
+    // periodic polling cadence rather than ~15x hotter.
+    if let Some(state) = device.device_state() {
+        if Utc::now() - state.updated < device.preferred_poll_interval() {
+            log::trace!("platform MQTT: skipping poll for {device}; state is still fresh");
+            return;
+        }
+    }
+
+    // A short cooldown additionally guards against a burst of concurrent polls
+    // for the same device while a poll is already in flight (last_polled has
+    // not been updated yet).
+    {
+        let mut map = cooldown.lock();
+        let now = Instant::now();
+        if let Some(last) = map.get(&device.id) {
+            if now.duration_since(*last) < POLL_COOLDOWN {
+                log::trace!("platform MQTT: skipping poll for {device}; within cooldown");
+                return;
+            }
+        }
+        map.insert(device.id.clone(), now);
+    }
+
+    log::info!("platform MQTT: polling {device} to refresh state after event");
+    if let Err(err) = state.poll_platform_api(device).await {
+        log::error!("platform MQTT: poll for {device} failed: {err:#}");
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Live connectivity smoke test against Govee's cloud MQTT broker.
+    /// Ignored by default since it needs network access and a real key.
+    /// Run with: `GOVEE_API_KEY=<key> cargo test --
+    /// service::platform_mqtt::test::live_connect_smoke --ignored --nocapture`
+    #[tokio::test]
+    #[ignore = "requires network access and GOVEE_API_KEY"]
+    async fn live_connect_smoke() {
+        let api_key = std::env::var("GOVEE_API_KEY")
+            .expect("set GOVEE_API_KEY in the environment to run this test");
+        let ca = resolve_ca_location(None).expect("a system CA bundle to be available");
+
+        let client = connect_platform_client(&api_key, &ca)
+            .await
+            .expect("connect to the Govee platform MQTT broker");
+        let subscriber = client.subscriber().expect("subscriber channel");
+
+        let topic = format!("GA/{api_key}");
+        client
+            .subscribe(&topic, QoS::AtMostOnce)
+            .await
+            .expect("subscribe to GA/<key>");
+        eprintln!("connected + subscribed to GA/<redacted> successfully");
+
+        // Drain any retained/immediate messages for a few seconds, if any.
+        let _ = timeout(Duration::from_secs(3), async {
+            while let Ok(event) = subscriber.recv().await {
+                match event {
+                    Event::Message(m) => {
+                        eprintln!(
+                            "message on {}: {}",
+                            m.topic,
+                            String::from_utf8_lossy(&m.payload)
+                        );
+                    }
+                    Event::Connected(s) => eprintln!("connected: {s}"),
+                    Event::Disconnected(r) => eprintln!("disconnected: {r}"),
+                }
+            }
+        })
+        .await;
+    }
+
+    #[test]
+    fn parse_ice_maker_out_of_water() {
+        let payload = br#"{
+            "sku": "H7172",
+            "device": "41:DA:D4:AD:FC:46:00:64",
+            "deviceName": "H7172",
+            "capabilities": [
+                {
+                    "type": "devices.capabilities.event",
+                    "instance": "lackWaterEvent",
+                    "state": [
+                        {"name": "lack", "value": 1, "message": "Lack of Water"}
+                    ]
+                }
+            ]
+        }"#;
+
+        let message: PlatformMessage = from_json(payload).unwrap();
+        assert_eq!(message.device.as_deref(), Some("41:DA:D4:AD:FC:46:00:64"));
+        assert_eq!(message.capabilities.len(), 1);
+        let cap = &message.capabilities[0];
+        assert_eq!(cap.kind, DeviceCapabilityKind::Event);
+        assert_eq!(cap.instance, "lackWaterEvent");
+
+        let entries: Vec<PlatformEventState> = serde_json::from_value(cap.state.clone()).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "lack");
+        assert_eq!(entries[0].value, json!(1));
+        assert_eq!(entries[0].message.as_deref(), Some("Lack of Water"));
+    }
+
+    #[test]
+    fn non_array_state_does_not_fail_message_parse() {
+        // A hypothetical state-style push where `state` is an object rather
+        // than an array must still parse at the message level.
+        let payload = br#"{
+            "sku": "H7172",
+            "device": "AA:BB",
+            "capabilities": [
+                {
+                    "type": "devices.capabilities.online",
+                    "instance": "online",
+                    "state": {"value": true}
+                }
+            ]
+        }"#;
+
+        let message: PlatformMessage = from_json(payload).unwrap();
+        assert_eq!(message.capabilities.len(), 1);
+        // And interpreting the object state as event entries yields nothing,
+        // rather than panicking.
+        let entries: Vec<PlatformEventState> =
+            serde_json::from_value(message.capabilities[0].state.clone()).unwrap_or_default();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn presence_event_parses() {
+        let payload = br#"{
+            "sku": "H5127",
+            "device": "06:30:60:74:F4:45:B9:DA",
+            "deviceName": "Presence Sensor",
+            "capabilities": [
+                {
+                    "type": "devices.capabilities.event",
+                    "instance": "bodyAppearedEvent",
+                    "state": [ {"name": "Presence", "value": 1} ]
+                }
+            ]
+        }"#;
+
+        let message: PlatformMessage = from_json(payload).unwrap();
+        let entries: Vec<PlatformEventState> =
+            serde_json::from_value(message.capabilities[0].state.clone()).unwrap();
+        assert_eq!(entries[0].name, "Presence");
+        assert_eq!(entries[0].message, None);
+    }
+}


### PR DESCRIPTION
## What

Implements platform-API event support so device events -- ice-maker-full, water-empty, presence, etc. -- appear in Home Assistant as native MQTT `event` entities, with no separate Mosquitto bridge required. This is the feature requested in #343.

## How

- **`src/service/platform_mqtt.rs`** -- a supervised subscription to Govee's documented cloud MQTT broker (`mqtt.openapi.govee.com:8883`, TLS, username = password = API key, topic `GA/<api-key>`, per the [Subscribe Device Event](https://developer.govee.com/reference/subscribe-device-event) docs). Robust reconnect was a specific goal: mosquitto's built-in auto-reconnect handles transient drops (we re-subscribe on every `Connected`), and an outer supervisor rebuilds the client with exponential backoff (2s->300s, reset after a healthy session) on connect failure or a clean broker-initiated close.
- **`src/hass_mqtt/event.rs`** -- a HASS MQTT `event` entity. `event_types` are derived from the device's `eventState` metadata returned by the platform API, so entities are created automatically during discovery for any `devices.capabilities.event` capability. Well-known instances get friendly names/icons (`iceFull` -> "Ice Maker Full" / `mdi:bucket`, `lackWaterEvent` -> "Out of Water" / `mdi:water-alert-outline`); anything else falls back to a humanized name.
- On an incoming event we publish `{event_type, name, value, message}` to the entity. Events we can't map to an entity, and any non-event state pushes, fall back to a **staleness-gated** platform poll (only when the device's state is older than its normal poll interval, plus a short per-device cooldown) so the rate-limited platform API isn't hammered.
- Enabled automatically when an API key is configured. Opt out with `--disable-platform-mqtt` (`GOVEE_DISABLE_PLATFORM_MQTT`). The TLS trust store is autodetected from the usual system locations; override with `--platform-mqtt-ca` (`GOVEE_MQTT_PLATFORM_CA`). Docs added in `docs/CONFIG.md`.

## Testing

- `cargo build`, `cargo test` (added unit tests for `eventState` parsing, value normalization, and entity name/icon mapping), `cargo clippy --all-targets`, and `cargo fmt --check` are all clean.
- Validated end-to-end on real hardware (H7172 ice maker): connects to the broker (`CONNACK 0`) and real `iceFull` events flow through to the HA `event` entity (observed firing repeatedly across a day). There's also an `#[ignore]`d `live_connect_smoke` test that connects with a real key for manual verification.

## Notes

- I don't have devices that emit every event type, so the friendly-name map covers the instances in the docs / #343; unknown instances degrade gracefully to a humanized name plus the poll fallback. Happy to adjust the naming/icon defaults.
- Unrelated to this change: the `test-addon` CI job currently fails for everyone because `home-assistant/builder@2026.02.1` pins cosign v2.5.3, which the cosign install script now rejects (it wants >= v2.6.0). Flagging so a red check there isn't attributed to this PR.

Closes #343
